### PR TITLE
Update dynamic versioning commands in build system

### DIFF
--- a/notes/migrate-existing-repo.md
+++ b/notes/migrate-existing-repo.md
@@ -341,6 +341,9 @@ teamtomo/                            # Monorepo root
 
 ### Version Configuration
 
+Teamtomo uses a dynamic versioning process through `hatch-vcs` to detect git tags with a package's specific version; these git tags follow a scheme of `<package-name>@v<x.y.z>`.
+Ensure the `[tool.hatch.version]` and `[tool.hatch.version.raw-options]` tables are updated accordingly:
+
 **Before (standalone):**
 
 ```toml
@@ -358,6 +361,12 @@ fallback-version = "0.0.1"
 
 [tool.hatch.version.raw-options]
 search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-grid-utils@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-grid-utils@v[0-9]*.[0-9]*.[0-9]*'"
+
 ```
 
 **Why:**
@@ -575,11 +584,16 @@ Version not detected, using fallback: 0.0.1
    tag-pattern = "^<package-name>@v(?P<version>.+)$"
    ```
 
-2. Ensure `search_parent_directories = true`:
+2. Ensure `search_parent_directories = true` and the `tag_regex` and `git_describe_command` fields match exactly:
 
    ```toml
    [tool.hatch.version.raw-options]
    search_parent_directories = true
+   # Parse tags of the form: <package-name>@v<semver>
+   tag_regex = "^torch-affine-utils@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+   # Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+   # See https://github.com/ofek/hatch-vcs/issues/71
+   git_describe_command = "git describe --dirty --tags --long --match 'torch-affine-utils@v[0-9]*.[0-9]*.[0-9]*'"
    ```
 
 3. Create a test tag:
@@ -673,6 +687,11 @@ Here are the exact changes made to migrate `torch-grid-utils`:
 +
 +[tool.hatch.version.raw-options]
 +search_parent_directories = true
++# Parse tags of the form: <package-name>@v<semver>
++tag_regex = "^torch-affine-utils@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
++# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
++# See https://github.com/ofek/hatch-vcs/issues/71
++git_describe_command = "git describe --dirty --tags --long --match 'torch-affine-utils@v[0-9]*.[0-9]*.[0-9]*'"
 ```
 
 **Changed lines (repository URLs):**

--- a/notes/migrate-existing-repo.md
+++ b/notes/migrate-existing-repo.md
@@ -159,21 +159,16 @@ cp ../../../LICENSE ./LICENSE
 **3. Modify `pyproject.toml`**
 
 Edit `packages/<category>/<package-name>/pyproject.toml`:
+Note that current Python tooling necessitates each sub-package has a fixed version rather than using some dynamic version resolving process. Ensure that 
 
-**Add/Update `[tool.hatch.version]` section:**
-
-```toml
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^<package-name>@v(?P<version>.+)$"
-fallback-version = "0.0.1"
-```
-
-**Add `[tool.hatch.version.raw-options]` section:**
+**Set fixed package version under `[project]` section:**
 
 ```toml
-[tool.hatch.version.raw-options]
-search_parent_directories = true  # Find .git in monorepo root
+# https://peps.python.org/pep-0621/
+[project]
+name = "<package-name>"
+version = "x.y.z"
+...
 ```
 
 **Update `[project.urls]`:**

--- a/packages/primitives/torch-affine-utils/pyproject.toml
+++ b/packages/primitives/torch-affine-utils/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-affine-utils@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 
 # read more about configuring hatch at:
@@ -22,7 +13,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-affine-utils"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Utilities for affine transforms of 2d/3d coordinates in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-affine-utils/pyproject.toml
+++ b/packages/primitives/torch-affine-utils/pyproject.toml
@@ -1,8 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-affine-utils@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-affine-utils@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-affine-utils@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -13,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-affine-utils"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Utilities for affine transforms of 2d/3d coordinates in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-ctf/pyproject.toml
+++ b/packages/primitives/torch-ctf/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-ctf@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-ctf"
-dynamic = ["version"]
+version = "0.5.0"
 description = "CTF calculation for cryoEM in torch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-ctf/pyproject.toml
+++ b/packages/primitives/torch-ctf/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-ctf@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-ctf@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-ctf@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-ctf"
-version = "0.5.0"
+dynamic = ["version"]
 description = "CTF calculation for cryoEM in torch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-cubic-spline-grids/pyproject.toml
+++ b/packages/primitives/torch-cubic-spline-grids/pyproject.toml
@@ -1,12 +1,12 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-cubic-spline-grids"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Cubic spline interpolation on multidimensional grids in PyTorch"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -57,6 +57,20 @@ dev = [
 # https://peps.python.org/pep-0621/#entry-points
 # [project.entry-points."spam.magical"]
 # tomatoes = "spam:main_tomatoes"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-cubic-spline-grids@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-cubic-spline-grids@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-cubic-spline-grids@v[0-9]*.[0-9]*.[0-9]*'"
 
 # https://hatch.pypa.io/latest/config/build/#file-selection
 # [tool.hatch.build.targets.sdist]

--- a/packages/primitives/torch-cubic-spline-grids/pyproject.toml
+++ b/packages/primitives/torch-cubic-spline-grids/pyproject.toml
@@ -1,11 +1,12 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-cubic-spline-grids"
+version = "0.5.0"
 description = "Cubic spline interpolation on multidimensional grids in PyTorch"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -24,7 +25,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dynamic = ["version"]
 dependencies = [
     "torch",
     "numpy",
@@ -57,15 +57,6 @@ dev = [
 # https://peps.python.org/pep-0621/#entry-points
 # [project.entry-points."spam.magical"]
 # tomatoes = "spam:main_tomatoes"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-cubic-spline-grids@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # https://hatch.pypa.io/latest/config/build/#file-selection
 # [tool.hatch.build.targets.sdist]

--- a/packages/primitives/torch-find-peaks/pyproject.toml
+++ b/packages/primitives/torch-find-peaks/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-find-peaks@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-find-peaks@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-find-peaks@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-find-peaks"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Peak finding and fitting using torch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-find-peaks/pyproject.toml
+++ b/packages/primitives/torch-find-peaks/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-find-peaks@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-find-peaks"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Peak finding and fitting using torch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-fourier-filter/pyproject.toml
+++ b/packages/primitives/torch-fourier-filter/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-fourier-filter@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-filter"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Filters for image and volumes in pyTorch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-fourier-filter/pyproject.toml
+++ b/packages/primitives/torch-fourier-filter/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-fourier-filter@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-fourier-filter@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-fourier-filter@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-filter"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Filters for image and volumes in pyTorch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-fourier-rescale/pyproject.toml
+++ b/packages/primitives/torch-fourier-rescale/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-fourier-rescale@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-fourier-rescale@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-fourier-rescale@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-rescale"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Rescale 2D and 3D images by Fourier padding/cropping in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-fourier-rescale/pyproject.toml
+++ b/packages/primitives/torch-fourier-rescale/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-fourier-rescale@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-rescale"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Rescale 2D and 3D images by Fourier padding/cropping in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-fourier-shell-correlation/pyproject.toml
+++ b/packages/primitives/torch-fourier-shell-correlation/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-fourier-shell-correlation@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-fourier-shell-correlation@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-fourier-shell-correlation@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-shell-correlation"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Compute the Fourier shell correlation in PyTorch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-fourier-shell-correlation/pyproject.toml
+++ b/packages/primitives/torch-fourier-shell-correlation/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-fourier-shell-correlation@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-shell-correlation"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Compute the Fourier shell correlation in PyTorch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-fourier-shift/pyproject.toml
+++ b/packages/primitives/torch-fourier-shift/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-fourier-shift@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-fourier-shift@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-fourier-shift@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-shift"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Shift 2D/3D images by phase shifting Fourier transforms in PyTorch"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/primitives/torch-fourier-shift/pyproject.toml
+++ b/packages/primitives/torch-fourier-shift/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-fourier-shift@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-shift"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Shift 2D/3D images by phase shifting Fourier transforms in PyTorch"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/primitives/torch-fourier-slice/pyproject.toml
+++ b/packages/primitives/torch-fourier-slice/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-fourier-slice@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-fourier-slice@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-fourier-slice@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-slice"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Fourier slice extraction/insertion in PyTorch."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-fourier-slice/pyproject.toml
+++ b/packages/primitives/torch-fourier-slice/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-fourier-slice@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-slice"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Fourier slice extraction/insertion in PyTorch."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/primitives/torch-grid-utils/pyproject.toml
+++ b/packages/primitives/torch-grid-utils/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-grid-utils@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-grid-utils@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-grid-utils@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-grid-utils"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Grid utilities for 2D/3D image manipulations in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-grid-utils/pyproject.toml
+++ b/packages/primitives/torch-grid-utils/pyproject.toml
@@ -1,17 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-grid-utils@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-# https://github.com/ofek/hatch-vcs#readme
-[tool.hatch.version.raw-options]
-search_parent_directories = true  # .git is in parent dir
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -22,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-grid-utils"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Grid utilities for 2D/3D image manipulations in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-image-interpolation/pyproject.toml
+++ b/packages/primitives/torch-image-interpolation/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-image-interpolation@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-image-interpolation"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Linear interpolation and gridding for 2D and 3D images in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-image-interpolation/pyproject.toml
+++ b/packages/primitives/torch-image-interpolation/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-image-interpolation@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-image-interpolation@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-image-interpolation@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-image-interpolation"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Linear interpolation and gridding for 2D and 3D images in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-so3/pyproject.toml
+++ b/packages/primitives/torch-so3/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-so3@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-so3@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-so3@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-so3"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Generate uniform 3D euler angles (ZYZ)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/primitives/torch-so3/pyproject.toml
+++ b/packages/primitives/torch-so3/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-so3@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-so3"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Generate uniform 3D euler angles (ZYZ)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/primitives/torch-subpixel-crop/pyproject.toml
+++ b/packages/primitives/torch-subpixel-crop/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-subpixel-crop@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-subpixel-crop@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-subpixel-crop@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-subpixel-crop"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Extract 2D/3D subimages with subpixel precision in PyTorch"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/primitives/torch-subpixel-crop/pyproject.toml
+++ b/packages/primitives/torch-subpixel-crop/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-subpixel-crop@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true  # Find .git in monorepo root
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-subpixel-crop"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Extract 2D/3D subimages with subpixel precision in PyTorch"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/primitives/torch-transform-image/pyproject.toml
+++ b/packages/primitives/torch-transform-image/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-transform-image@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-transform-image"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Real space transformations of 2D/3D images in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/primitives/torch-transform-image/pyproject.toml
+++ b/packages/primitives/torch-transform-image/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-transform-image@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-transform-image@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-transform-image@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-transform-image"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Real space transformations of 2D/3D images in PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/wip/torch-tilt-series/pyproject.toml
+++ b/packages/wip/torch-tilt-series/pyproject.toml
@@ -1,16 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# https://hatch.pypa.io/latest/config/metadata/
-[tool.hatch.version]
-source = "vcs"
-tag-pattern = "^torch-tilt-series@v(?P<version>.+)$"
-fallback-version = "0.5.0"
-
-[tool.hatch.version.raw-options]
-search_parent_directories = true
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -21,7 +12,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-tilt-series"
-dynamic = ["version"]
+version = "0.5.0"
 description = "Tomogram reconstruction, subtomogram reconstruction, and subtilt extraction for cryo-ET."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/wip/torch-tilt-series/pyproject.toml
+++ b/packages/wip/torch-tilt-series/pyproject.toml
@@ -1,7 +1,21 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^torch-tilt-series@v(?P<version>.+)$"
+fallback-version = "0.5.0"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^torch-tilt-series@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'torch-tilt-series@v[0-9]*.[0-9]*.[0-9]*'"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
@@ -12,7 +26,7 @@ sources = ["src"]
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-tilt-series"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Tomogram reconstruction, subtomogram reconstruction, and subtilt extraction for cryo-ET."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ source = "vcs"
 tag-pattern = "^teamtomo@v(?P<version>.+)$"
 fallback-version = "0.5.0"
 
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+# Parse tags of the form: <package-name>@v<semver>
+tag_regex = "^teamtomo@v(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+# Constrain git-describe so it only considers TeamTomo's own tags, not other workspace tags.
+# See https://github.com/ofek/hatch-vcs/issues/71
+git_describe_command = "git describe --dirty --tags --long --match 'teamtomo@v[0-9]*.[0-9]*.[0-9]*'"
 
 [dependency-groups]
 test = ["pytest", "pytest-cov"]

--- a/uv.lock
+++ b/uv.lock
@@ -3127,7 +3127,6 @@ wheels = [
 
 [[package]]
 name = "torch-affine-utils"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-affine-utils" }
 dependencies = [
     { name = "einops" },
@@ -3170,7 +3169,6 @@ test = [
 
 [[package]]
 name = "torch-ctf"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-ctf" }
 dependencies = [
     { name = "einops" },
@@ -3221,7 +3219,6 @@ test = [
 
 [[package]]
 name = "torch-cubic-spline-grids"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-cubic-spline-grids" }
 dependencies = [
     { name = "einops" },
@@ -3272,7 +3269,6 @@ test = [
 
 [[package]]
 name = "torch-find-peaks"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-find-peaks" }
 dependencies = [
     { name = "pandas" },
@@ -3339,7 +3335,6 @@ test = [
 
 [[package]]
 name = "torch-fourier-filter"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-filter" }
 dependencies = [
     { name = "einops" },
@@ -3378,7 +3373,6 @@ test = [
 
 [[package]]
 name = "torch-fourier-rescale"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-rescale" }
 dependencies = [
     { name = "einops" },
@@ -3427,7 +3421,6 @@ test = [
 
 [[package]]
 name = "torch-fourier-shell-correlation"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-shell-correlation" }
 dependencies = [
     { name = "numpy" },
@@ -3476,7 +3469,6 @@ test = [
 
 [[package]]
 name = "torch-fourier-shift"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-shift" }
 dependencies = [
     { name = "einops" },
@@ -3533,7 +3525,6 @@ test = [
 
 [[package]]
 name = "torch-fourier-slice"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-slice" }
 dependencies = [
     { name = "einops" },
@@ -3606,7 +3597,6 @@ test = [
 
 [[package]]
 name = "torch-grid-utils"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-grid-utils" }
 dependencies = [
     { name = "einops" },
@@ -3657,7 +3647,6 @@ test = [
 
 [[package]]
 name = "torch-image-interpolation"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-image-interpolation" }
 dependencies = [
     { name = "einops" },
@@ -3706,7 +3695,6 @@ test = [
 
 [[package]]
 name = "torch-so3"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-so3" }
 dependencies = [
     { name = "healpy", marker = "sys_platform != 'win32'" },
@@ -3755,7 +3743,6 @@ test = [
 
 [[package]]
 name = "torch-subpixel-crop"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-subpixel-crop" }
 dependencies = [
     { name = "einops" },
@@ -3808,7 +3795,6 @@ test = [
 
 [[package]]
 name = "torch-tilt-series"
-version = "0.5.0"
 source = { editable = "packages/wip/torch-tilt-series" }
 dependencies = [
     { name = "alnfile" },
@@ -3871,7 +3857,6 @@ test = [
 
 [[package]]
 name = "torch-transform-image"
-version = "0.5.0"
 source = { editable = "packages/primitives/torch-transform-image" }
 dependencies = [
     { name = "torch" },

--- a/uv.lock
+++ b/uv.lock
@@ -3127,6 +3127,7 @@ wheels = [
 
 [[package]]
 name = "torch-affine-utils"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-affine-utils" }
 dependencies = [
     { name = "einops" },
@@ -3169,6 +3170,7 @@ test = [
 
 [[package]]
 name = "torch-ctf"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-ctf" }
 dependencies = [
     { name = "einops" },
@@ -3219,6 +3221,7 @@ test = [
 
 [[package]]
 name = "torch-cubic-spline-grids"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-cubic-spline-grids" }
 dependencies = [
     { name = "einops" },
@@ -3269,6 +3272,7 @@ test = [
 
 [[package]]
 name = "torch-find-peaks"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-find-peaks" }
 dependencies = [
     { name = "pandas" },
@@ -3335,6 +3339,7 @@ test = [
 
 [[package]]
 name = "torch-fourier-filter"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-filter" }
 dependencies = [
     { name = "einops" },
@@ -3373,6 +3378,7 @@ test = [
 
 [[package]]
 name = "torch-fourier-rescale"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-rescale" }
 dependencies = [
     { name = "einops" },
@@ -3421,6 +3427,7 @@ test = [
 
 [[package]]
 name = "torch-fourier-shell-correlation"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-shell-correlation" }
 dependencies = [
     { name = "numpy" },
@@ -3469,6 +3476,7 @@ test = [
 
 [[package]]
 name = "torch-fourier-shift"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-shift" }
 dependencies = [
     { name = "einops" },
@@ -3525,6 +3533,7 @@ test = [
 
 [[package]]
 name = "torch-fourier-slice"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-fourier-slice" }
 dependencies = [
     { name = "einops" },
@@ -3597,6 +3606,7 @@ test = [
 
 [[package]]
 name = "torch-grid-utils"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-grid-utils" }
 dependencies = [
     { name = "einops" },
@@ -3647,6 +3657,7 @@ test = [
 
 [[package]]
 name = "torch-image-interpolation"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-image-interpolation" }
 dependencies = [
     { name = "einops" },
@@ -3695,6 +3706,7 @@ test = [
 
 [[package]]
 name = "torch-so3"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-so3" }
 dependencies = [
     { name = "healpy", marker = "sys_platform != 'win32'" },
@@ -3743,6 +3755,7 @@ test = [
 
 [[package]]
 name = "torch-subpixel-crop"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-subpixel-crop" }
 dependencies = [
     { name = "einops" },
@@ -3795,6 +3808,7 @@ test = [
 
 [[package]]
 name = "torch-tilt-series"
+version = "0.5.0"
 source = { editable = "packages/wip/torch-tilt-series" }
 dependencies = [
     { name = "alnfile" },
@@ -3857,6 +3871,7 @@ test = [
 
 [[package]]
 name = "torch-transform-image"
+version = "0.5.0"
 source = { editable = "packages/primitives/torch-transform-image" }
 dependencies = [
     { name = "torch" },


### PR DESCRIPTION
After trying to get the `vcs` package versioning working locally with some package tags (e.g. `torch-grid-utils@v0.5.0`) _and_ after doing some research on what's possible with the current hatch build system, I've adjusted all sub-packages to use a fixed versioning system where `pyproject.toml` files are used to define package versions rather than from a git tag.

@alisterburt This is not optimal for package ease-of-release since a developer would have to 1) bump the package versions manually, then 2) use some tagging mechanism to trigger a new release. Some CI mechanism could verify that a tagged version matches what gets tagged.

## Todo before merging

 - [x] Verify dynamic versioning for `teamtomo` metarepo still works
 - [ ] Test out CI release mechanism with new versioning system
 - [x] Update development notes accordingly