### PR TITLE
Allow packages to be imported from `teamtomo` namespace

### DIFF
--- a/src/teamtomo/__init__.py
+++ b/src/teamtomo/__init__.py
@@ -1,2 +1,21 @@
+"""Modular Python packages for cryo-EM and cryo-ET."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("teamtomo")
+except PackageNotFoundError:
+    __version__ = "uninstalled"
+
+# Import sub-namespaces
+from teamtomo import primitives, wip
+
+__all__ = [
+    "__version__",
+    "primitives",
+    "wip",
+]
+
+
 def hello() -> str:
     return "Hello from teamtomo!"

--- a/src/teamtomo/primitives/__init__.py
+++ b/src/teamtomo/primitives/__init__.py
@@ -1,0 +1,89 @@
+"""Primitive packages for cryo-EM and cryo-ET operations."""
+
+# Import all primitive packages
+try:
+    import torch_affine_utils
+except ImportError:
+    torch_affine_utils = None
+
+try:
+    import torch_ctf
+except ImportError:
+    torch_ctf = None
+
+try:
+    import torch_cubic_spline_grids
+except ImportError:
+    torch_cubic_spline_grids = None
+
+try:
+    import torch_find_peaks
+except ImportError:
+    torch_find_peaks = None
+
+try:
+    import torch_fourier_filter
+except ImportError:
+    torch_fourier_filter = None
+
+try:
+    import torch_fourier_rescale
+except ImportError:
+    torch_fourier_rescale = None
+
+try:
+    import torch_fourier_shell_correlation
+except ImportError:
+    torch_fourier_shell_correlation = None
+
+try:
+    import torch_fourier_shift
+except ImportError:
+    torch_fourier_shift = None
+
+try:
+    import torch_fourier_slice
+except ImportError:
+    torch_fourier_slice = None
+
+try:
+    import torch_grid_utils
+except ImportError:
+    torch_grid_utils = None
+
+try:
+    import torch_image_interpolation
+except ImportError:
+    torch_image_interpolation = None
+
+try:
+    import torch_so3
+except ImportError:
+    torch_so3 = None
+
+try:
+    import torch_subpixel_crop
+except ImportError:
+    torch_subpixel_crop = None
+
+try:
+    import torch_transform_image
+except ImportError:
+    torch_transform_image = None
+
+__all__ = [
+    "torch_affine_utils",
+    "torch_ctf",
+    "torch_cubic_spline_grids",
+    "torch_find_peaks",
+    "torch_fourier_filter",
+    "torch_fourier_rescale",
+    "torch_fourier_shell_correlation",
+    "torch_fourier_shift",
+    "torch_fourier_slice",
+    "torch_grid_utils",
+    "torch_image_interpolation",
+    "torch_so3",
+    "torch_subpixel_crop",
+    "torch_transform_image",
+]

--- a/src/teamtomo/wip/__init__.py
+++ b/src/teamtomo/wip/__init__.py
@@ -1,0 +1,11 @@
+"""WIP (work-in-progress) packages for cryo-EM and cryo-ET operations."""
+
+# Import all WIP packages
+try:
+    import torch_tilt_series
+except ImportError:
+    torch_tilt_series = None
+
+__all__ = [
+    "torch_tilt_series",
+]

--- a/tests/test_teamtomo_imports.py
+++ b/tests/test_teamtomo_imports.py
@@ -1,0 +1,84 @@
+"""Check that all modules are importable under the teamtomo namespace."""
+
+import pytest
+
+
+def test_primitives_import():
+    """Ensure teamtomo.primitives can be imported."""
+    from teamtomo import primitives
+
+    assert primitives is not None
+
+
+def test_wip_imports():
+    """Ensure teamtomo.wip modules can be imported."""
+    from teamtomo import wip
+
+    assert wip is not None
+
+
+def test_individual_primitive_imports():
+    """Test that individual primitive packages can be imported."""
+    from teamtomo.primitives import (
+        torch_affine_utils,
+        torch_ctf,
+        torch_cubic_spline_grids,
+        torch_find_peaks,
+        torch_fourier_filter,
+        torch_fourier_rescale,
+        torch_fourier_shell_correlation,
+        torch_fourier_shift,
+        torch_fourier_slice,
+        torch_grid_utils,
+        torch_image_interpolation,
+        torch_so3,
+        torch_subpixel_crop,
+        torch_transform_image,
+    )
+
+    assert torch_affine_utils is not None
+    assert torch_ctf is not None
+    assert torch_cubic_spline_grids is not None
+    assert torch_find_peaks is not None
+    assert torch_fourier_filter is not None
+    assert torch_fourier_rescale is not None
+    assert torch_fourier_shell_correlation is not None
+    assert torch_fourier_shift is not None
+    assert torch_fourier_slice is not None
+    assert torch_grid_utils is not None
+    assert torch_image_interpolation is not None
+    assert torch_so3 is not None
+    assert torch_subpixel_crop is not None
+    assert torch_transform_image is not None
+
+
+def test_all_primitives_available():
+    """Verify all primitive packages are in the namespace."""
+    from teamtomo import primitives
+
+    expected_packages = [
+        "torch_affine_utils",
+        "torch_ctf",
+        "torch_cubic_spline_grids",
+        "torch_find_peaks",
+        "torch_fourier_filter",
+        "torch_fourier_rescale",
+        "torch_fourier_shell_correlation",
+        "torch_fourier_shift",
+        "torch_fourier_slice",
+        "torch_grid_utils",
+        "torch_image_interpolation",
+        "torch_so3",
+        "torch_subpixel_crop",
+        "torch_transform_image",
+    ]
+
+    for pkg in expected_packages:
+        assert hasattr(primitives, pkg), f"Missing package: {pkg}"
+
+
+def test_wip_packages_available():
+    """Verify WIP packages are in the namespace."""
+    from teamtomo import wip
+
+    assert hasattr(wip, "torch_tilt_series")


### PR DESCRIPTION
For example, can access primitives packages as follows:

```python
from teamtomo.primitives import torch_ctf

# CTF functions from `torch-ctf` module can now be accessed
```

Note: this currently only works as workspace install since no `teamtomo` package on PyPI...