### PR TITLE
Split CI/CD into multiple workflows

### DIFF
--- a/.github/scripts/get_all_packages.py
+++ b/.github/scripts/get_all_packages.py
@@ -1,0 +1,35 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def get_all_packages() -> list[str]:
+    """Get all workspace package names."""
+    workspace_packages = []
+
+    # Define workspace member glob patterns (same as pyproject.toml)
+    patterns = [
+        "packages/io/*/pyproject.toml",
+        "packages/primitives/*/pyproject.toml",
+        "packages/algorithms/*/pyproject.toml",
+        "packages/wip/*/pyproject.toml",
+    ]
+
+    for pattern in patterns:
+        for pyproject in Path(".").glob(pattern):
+            # Parse pyproject.toml to get package name
+            content = pyproject.read_text()
+
+            for line in content.split("\n"):
+                if line.startswith('name = "'):
+                    pkg_name = line.split('"')[1]
+                    workspace_packages.append(pkg_name)
+                    break
+
+    return sorted(workspace_packages)
+
+
+if __name__ == "__main__":
+    packages = get_all_packages()
+    for pkg in packages:
+        print(pkg)

--- a/.github/scripts/get_all_packages.py
+++ b/.github/scripts/get_all_packages.py
@@ -1,35 +1,47 @@
-import json
-import subprocess
+import sys
+import tomllib
 from pathlib import Path
 
+# Define workspace member glob patterns (same as pyproject.toml)
+PATTERNS = [
+    "packages/io/*/pyproject.toml",
+    "packages/primitives/*/pyproject.toml",
+    "packages/algorithms/*/pyproject.toml",
+    "packages/wip/*/pyproject.toml",
+]
 
-def get_all_packages() -> list[str]:
-    """Get all workspace package names."""
-    workspace_packages = []
 
-    # Define workspace member glob patterns (same as pyproject.toml)
-    patterns = [
-        "packages/io/*/pyproject.toml",
-        "packages/primitives/*/pyproject.toml",
-        "packages/algorithms/*/pyproject.toml",
-        "packages/wip/*/pyproject.toml",
-    ]
+def get_all_packages() -> dict[str, Path]:
+    """Get all workspace package names and their directories."""
+    workspace_packages = {}
 
-    for pattern in patterns:
+    for pattern in PATTERNS:
         for pyproject in Path(".").glob(pattern):
-            # Parse pyproject.toml to get package name
-            content = pyproject.read_text()
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+                pkg_name = data.get("project", {}).get("name")
+                if pkg_name:
+                    workspace_packages[pkg_name] = pyproject.parent
 
-            for line in content.split("\n"):
-                if line.startswith('name = "'):
-                    pkg_name = line.split('"')[1]
-                    workspace_packages.append(pkg_name)
-                    break
+    return dict(sorted(workspace_packages.items()))
 
-    return sorted(workspace_packages)
+
+def find_package_path(package_name: str) -> Path:
+    """Find the workspace directory for a given package name."""
+    packages = get_all_packages()
+    if package_name not in packages:
+        print(f"ERROR: Package '{package_name}' not found in workspace", file=sys.stderr)
+        print(f"Available packages: {', '.join(packages.keys())}", file=sys.stderr)
+        sys.exit(1)
+    return packages[package_name]
 
 
 if __name__ == "__main__":
-    packages = get_all_packages()
-    for pkg in packages:
-        print(pkg)
+    if len(sys.argv) > 1:
+        # If a package name is provided, print its path
+        path = find_package_path(sys.argv[1])
+        print(path)
+    else:
+        # Otherwise, print all package names
+        for pkg_name in get_all_packages():
+            print(pkg_name)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
+# --- Testing workflow for all packages in workspace ---
+#
+# This CI workflow runs on pushes to the main branch, pull requests, and on a schedule (weekly).
+# It tests the entire package leveraging the uv workspace to recursively run tests across all
+# know packages and across multiple Python versions (3.11, 3.12, 3.13).
+# NOTE: No deployment or publishing steps are included in this workflow.
+
 name: CI
 
 on:
   push:
     branches: [main]
-    tags: ["*@v*"] # scoped tags e.g. 'torch-grid-utils@v1.0.0'
   pull_request:
   workflow_dispatch:
   schedule:
@@ -14,79 +20,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # --- phase 1a: discover packages to test and deploy ---
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      packages: ${{ steps.set-matrix.outputs.packages }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Critical for git diff logic in discovery script
-      - uses: astral-sh/setup-uv@v7
-      - name: find packages to test
-        id: set-matrix
-        run: python .github/scripts/find_packages_to_test_and_deploy.py >> $GITHUB_OUTPUT
-
-  # --- phase 1b: handle coordinated releases ---
-  #     When a tag named `teamtomo@v*` is
-  #     pushed, then all workspace packages
-  #     are tagged and releases triggered
-  coordinate-release:
-    runs-on: ubuntu-latest
-    if: |
-      contains(github.ref, 'teamtomo@v') && 
-      github.ref_type == 'tag' &&
-      github.event_name == 'push'
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
-
-      - name: Extract version from meta-tag
-        id: version
-        run: |
-          TAG_NAME=${{ github.ref_name }}
-          VERSION=${TAG_NAME#teamtomo@}  # Remove 'teamtomo@' prefix
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Coordinated release: $VERSION"
-
-      - name: Tag all workspace packages
-        run: |
-          # Get all packages from workspace
-          PACKAGES=$(python .github/scripts/get_all_packages.py)
-          
-          for pkg_name in $PACKAGES; do
-            TAG="${pkg_name}@${{ steps.version.outputs.version }}"
-            echo "Creating tag: $TAG"
-            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-              git tag "$TAG"
-            fi
-          done
-
-          git push origin --tags
-
-      - name: Trigger deployment workflow
-        run: |
-          # GitHub Actions picks up the new tags automatically
-          echo "✅ Tagged all packages. Deployment jobs will trigger automatically."
-
-  # --- phase 2: test relevant packages ---
   test:
-    needs: detect-changes
-    # Don't run if no packages were affected (e.g., only a README change)
-    if: needs.detect-changes.outputs.packages != '[]'
-    # Use the 'name' property for the job display label
-    name: ${{ matrix.package.name }} | ${{ matrix.python-version }}
+    name: Test All Packages | Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -100,75 +40,13 @@ jobs:
             **/pyproject.toml
             uv.lock
 
-      - name: Install Package Dependencies
-        run: |
-          uv sync \
-            --python ${{ matrix.python-version }} \
-            --no-dev \
-            --group test \
-            --project ${{ matrix.package.path }}
+      - name: Install all workspace dependencies
+        run: uv sync --all-packages --group test
 
-      - name: Print Environment Info
+      - name: Print environment info
         run: |
           uv run python -V
-          uv run which pytest
           uv run pytest --version
 
-      - name: Run Tests
-        run: |
-          uv run pytest ${{ matrix.package.path }} \
-            --cov=${{ matrix.package.path }} \
-            --cov-report=xml
-
-  # --- phase 3: deployment ---
-  deploy:
-    needs: test
-    # If statement selects to only run on version tags pushed to main
-    if: |
-      success() && 
-      contains(github.ref, '@v') && 
-      github.event_name != 'schedule' && 
-      github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Needed for hatch-vcs to see tags
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
-
-      - name: verify tag on main branch
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
-            echo "Error: Tag is not on main branch. Will not proceed with deployment"
-            exit 1
-          fi
-
-      - name: get package name
-        id: info
-        run: |
-          # Extracts 'torch-grid-utils' from 'refs/tags/torch-grid-utils@v1.0.0'
-          TAG_NAME=${{ github.ref_name }}
-          echo "pkg_name=${TAG_NAME%@*}" >> $GITHUB_OUTPUT
-
-      - name: ⚙️ Install Build Dependencies
-        run: uv sync --dev
-
-      - name: 👷 Build Package
-        run: uv build --package ${{ steps.info.outputs.pkg_name }}
-
-      - name: 🚢 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: 📝 Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: './dist/*'
+      - name: Run all tests
+        run: uv run pytest --cov --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@
 #
 # This CI workflow runs on pushes to the main branch, pull requests, and on a schedule (weekly).
 # It tests the entire package leveraging the uv workspace to recursively run tests across all
-# know packages and across multiple Python versions (3.11, 3.12, 3.13).
-# NOTE: No deployment or publishing steps are included in this workflow.
+# known packages and across multiple Python versions (3.11, 3.12, 3.13).
+# NOTE: Deployment is handled by the separate deploy.yaml workflow triggered on package
+# tags; this CI workflow only runs tests and does not publish packages.
 
 name: CI
 
@@ -48,5 +49,7 @@ jobs:
           uv run python -V
           uv run pytest --version
 
+      # NOTE: base pyproject.toml configuration already discovers all packages
+      # in the workspace, so no need to specify paths here.
       - name: Run all tests
-        run: uv run pytest --cov --cov-report=xml
+        run: uv run pytest --cov=packages/ --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # --- phase 1: discover packages to test and deploy ---
+  # --- phase 1a: discover packages to test and deploy ---
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -27,6 +27,52 @@ jobs:
       - name: find packages to test
         id: set-matrix
         run: python .github/scripts/find_packages_to_test_and_deploy.py >> $GITHUB_OUTPUT
+
+  # --- phase 1b: handle coordinated releases ---
+  #     When a tag named `teamtomo@v*` is
+  #     pushed, then all workspace packages
+  #     are tagged and releases triggered
+  coordinate-release:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.ref, 'teamtomo@v') && 
+      github.ref_type == 'tag' &&
+      github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Extract version from meta-tag
+        id: version
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          VERSION=${TAG_NAME#teamtomo@}  # Remove 'teamtomo@' prefix
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Coordinated release: $VERSION"
+
+      - name: Tag all workspace packages
+        run: |
+          # Get all packages from workspace
+          PACKAGES=$(python .github/scripts/get_all_packages.py)
+          
+          for pkg_name in $PACKAGES; do
+            TAG="${pkg_name}@${{ steps.version.outputs.version }}"
+            echo "Creating tag: $TAG"
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              git tag "$TAG"
+            fi
+          done
+
+          git push origin --tags
+
+      - name: Trigger deployment workflow
+        run: |
+          # GitHub Actions picks up the new tags automatically
+          echo "✅ Tagged all packages. Deployment jobs will trigger automatically."
 
   # --- phase 2: test relevant packages ---
   test:
@@ -50,6 +96,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            uv.lock
 
       - name: Install Package Dependencies
         run: |
@@ -79,8 +128,7 @@ jobs:
       success() && 
       contains(github.ref, '@v') && 
       github.event_name != 'schedule' && 
-      github.ref_type == 'tag' &&
-      github.event.base_ref == 'refs/heads/main'
+      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -95,12 +143,23 @@ jobs:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
 
+      - name: verify tag on main branch
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "Error: Tag is not on main branch. Will not proceed with deployment"
+            exit 1
+          fi
+
       - name: get package name
         id: info
         run: |
           # Extracts 'torch-grid-utils' from 'refs/tags/torch-grid-utils@v1.0.0'
           TAG_NAME=${{ github.ref_name }}
           echo "pkg_name=${TAG_NAME%@*}" >> $GITHUB_OUTPUT
+
+      - name: ⚙️ Install Build Dependencies
+        run: uv sync --dev
 
       - name: 👷 Build Package
         run: uv build --package ${{ steps.info.outputs.pkg_name }}

--- a/.github/workflows/coordinated_release.yml
+++ b/.github/workflows/coordinated_release.yml
@@ -1,0 +1,79 @@
+# --- Coordinated release workflow for whole TeamTomo package ---
+#
+# This workflow triggers after CI completes successfully on the main branch.
+# It checks if the commit has a 'teamtomo@v*' tag, and if so, tags all workspace
+# packages with the same version to trigger individual deployment workflows.
+#
+# Steps:
+# 1. Waits for CI workflow to complete successfully
+# 2. Checks if the commit has a 'teamtomo@v*' tag
+# 3. If found, extracts the version and tags all workspace packages
+# 4. Pushes tags to trigger individual package deployments
+
+name: Coordinate Release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  coordinate-release:
+    # Only proceed if CI passed
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Check for teamtomo release tag
+        id: check-tag
+        run: |
+          COMMIT_SHA=${{ github.event.workflow_run.head_sha }}
+          echo "Checking commit $COMMIT_SHA for teamtomo@v* tag"
+          
+          # Find all tags pointing to this commit
+          TAGS=$(git tag --points-at $COMMIT_SHA)
+          TEAMTOMO_TAG=$(echo "$TAGS" | grep '^teamtomo@v' | head -n1 || echo "")
+          
+          if [ -z "$TEAMTOMO_TAG" ]; then
+            echo "No teamtomo@v* tag found on this commit"
+            echo "has_tag=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          VERSION=${TEAMTOMO_TAG#teamtomo@}
+          echo "Found release tag: $TEAMTOMO_TAG"
+          echo "has_tag=true" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Tag all workspace packages
+        if: steps.check-tag.outputs.has_tag == 'true'
+        run: |
+          VERSION=${{ steps.check-tag.outputs.version }}
+          echo "Coordinating release: $VERSION"
+          echo "✅ CI already passed for this commit"
+          
+          PACKAGES=$(python .github/scripts/get_all_packages.py)
+          
+          for pkg_name in $PACKAGES; do
+            TAG="${pkg_name}@${VERSION}"
+            echo "Creating tag: $TAG"
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              git tag "$TAG"
+            else
+              echo "Tag $TAG already exists, skipping"
+            fi
+          done
+
+          git push origin --tags
+          echo "✅ Tagged all packages. Individual deployment jobs will trigger automatically."

--- a/.github/workflows/coordinated_release.yml
+++ b/.github/workflows/coordinated_release.yml
@@ -13,58 +13,62 @@
 name: Coordinate Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - main
+  push:
+    tags:
+      - "teamtomo@v*"
 
 permissions:
   contents: write
 
 jobs:
   coordinate-release:
-    # Only proceed if CI passed
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TEAMTOMO_APP_ID }}
+          private-key: ${{ secrets.TEAMTOMO_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: astral-sh/setup-uv@v7
 
-      - name: Check for teamtomo release tag
+      - name: Wait for CI to pass
+        uses: lewagon/wait-on-check-action@v1.5.0
+        with:
+          ref: ${{ github.sha }}
+          check-name: "Test All Packages | Python 3.13"  # NOTE: Must match the CI job name for Python 3.13
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+      - name: Extract version from tag
         id: check-tag
         run: |
-          COMMIT_SHA=${{ github.event.workflow_run.head_sha }}
-          echo "Checking commit $COMMIT_SHA for teamtomo@v* tag"
-          
-          # Find all tags pointing to this commit
-          TAGS=$(git tag --points-at $COMMIT_SHA)
-          TEAMTOMO_TAG=$(echo "$TAGS" | grep '^teamtomo@v' | head -n1 || echo "")
-          
-          if [ -z "$TEAMTOMO_TAG" ]; then
-            echo "No teamtomo@v* tag found on this commit"
-            echo "has_tag=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          VERSION=${TEAMTOMO_TAG#teamtomo@}
-          echo "Found release tag: $TEAMTOMO_TAG"
-          echo "has_tag=true" >> $GITHUB_OUTPUT
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#teamtomo@}
+          echo "Found release tag: $TAG"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Tag all workspace packages
-        if: steps.check-tag.outputs.has_tag == 'true'
         run: |
           VERSION=${{ steps.check-tag.outputs.version }}
           echo "Coordinating release: $VERSION"
-          echo "✅ CI already passed for this commit"
-          
-          PACKAGES=$(python .github/scripts/get_all_packages.py)
-          
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          PACKAGES=$(uv run python .github/scripts/get_all_packages.py)
+
           for pkg_name in $PACKAGES; do
             TAG="${pkg_name}@${VERSION}"
             echo "Creating tag: $TAG"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,15 +52,24 @@ jobs:
           COMMIT_SHA=$(git rev-list -n 1 ${{ github.ref }})
           echo "Checking CI status for commit: $COMMIT_SHA"
 
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$COMMIT_SHA/status --jq '.state')
-          echo "CI status: $STATUS"
+          # Query check runs (GitHub Actions reports as check runs, not commit statuses)
+          CI_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$COMMIT_SHA/check-runs" \
+            --jq '.check_runs[] | select(.name | startswith("Test All Packages")) | .conclusion' \
+            | sort -u)
 
-          if [ "$STATUS" != "success" ]; then
-            echo "ERROR: CI checks have not passed (status: $STATUS). Cannot deploy."
+          echo "CI conclusions: $CI_CONCLUSION"
+
+          if echo "$CI_CONCLUSION" | grep -q "failure"; then
+            echo "❌ CI failed. Cannot deploy."
             exit 1
           fi
 
-          echo "CI passed. Proceeding with deploy."
+          if ! echo "$CI_CONCLUSION" | grep -q "success"; then
+            echo "❌ CI has not completed successfully. Cannot deploy."
+            exit 1
+          fi
+
+          echo "✅ CI passed. Proceeding with deploy."
 
       - name: Extract package name from tag
         id: info
@@ -74,20 +83,17 @@ jobs:
         run: |
           uv sync --package ${{ steps.info.outputs.pkg_name }} --group test
 
+      - name: Find package directory
+        id: pkg-dir
+        run: |
+          PKG_DIR=$(python .github/scripts/get_all_packages.py ${{ steps.info.outputs.pkg_name }})
+          echo "pkg_dir=$PKG_DIR" >> $GITHUB_OUTPUT
+          echo "Package directory: $PKG_DIR"
+
       - name: Test package before deployment
         run: |
-          PKG_PATH=$(uv run python -c "import importlib.util; import sys; spec = importlib.util.find_spec('${{ steps.info.outputs.pkg_name }}'); print(spec.origin if spec else ''); sys.exit(0 if spec else 1)")
-          if [ -z "$PKG_PATH" ]; then
-            echo "ERROR: Package not found"
-            exit 1
-          fi
-          
-          PKG_DIR=$(dirname $(dirname "$PKG_PATH"))
-          echo "Testing package at: $PKG_DIR"
-          uv run pytest "$PKG_DIR" --cov="$PKG_DIR" --cov-report=xml
-
-      - name: Install build dependencies
-        run: uv sync --dev
+          uv run pytest ${{ steps.pkg-dir.outputs.pkg_dir }} \
+            --cov=${{ steps.pkg-dir.outputs.pkg_dir }} --cov-report=xml
 
       - name: Build package
         run: uv build --package ${{ steps.info.outputs.pkg_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,102 @@
+# --- Deployment workflow for a single package in TeamTomo ---
+#
+# Workflow will be triggered on pushes to tags matching the pattern "*@v*" (e.g., "package@v1.0.0"),
+# but excluding tags starting with "teamtomo@" which is reserved for a coordinated release process.
+# The workflow performs the following steps:
+# 1. Verifies that the tag is on the main branch to ensure only stable code is deployed.
+# 2. Checks that the CI tests have passed for the commit associated with the tag.
+# 3. Extracts the package name from the tag and runs tests for that specific package to ensure it is functioning correctly.
+# 4. Builds the package and publishes it to PyPI.
+# 5. Creates a GitHub Release with the built package attached.
+
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "*@v*"
+      - "!teamtomo@v*"
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Verify tag on main branch
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "ERROR: Tag is not on main branch. Cannot deploy."
+            exit 1
+          fi
+
+      - name: Verify CI passed for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMIT_SHA=$(git rev-list -n 1 ${{ github.ref }})
+          echo "Checking CI status for commit: $COMMIT_SHA"
+
+          STATUS=$(gh api repos/${{ github.repository }}/commits/$COMMIT_SHA/status --jq '.state')
+          echo "CI status: $STATUS"
+
+          if [ "$STATUS" != "success" ]; then
+            echo "ERROR: CI checks have not passed (status: $STATUS). Cannot deploy."
+            exit 1
+          fi
+
+          echo "CI passed. Proceeding with deploy."
+
+      - name: Extract package name from tag
+        id: info
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          PKG_NAME=${TAG_NAME%@*}
+          echo "pkg_name=$PKG_NAME" >> $GITHUB_OUTPUT
+          echo "Deploying package: $PKG_NAME"
+
+      - name: Install package dependencies
+        run: |
+          uv sync --package ${{ steps.info.outputs.pkg_name }} --group test
+
+      - name: Test package before deployment
+        run: |
+          PKG_PATH=$(uv run python -c "import importlib.util; import sys; spec = importlib.util.find_spec('${{ steps.info.outputs.pkg_name }}'); print(spec.origin if spec else ''); sys.exit(0 if spec else 1)")
+          if [ -z "$PKG_PATH" ]; then
+            echo "ERROR: Package not found"
+            exit 1
+          fi
+          
+          PKG_DIR=$(dirname $(dirname "$PKG_PATH"))
+          echo "Testing package at: $PKG_DIR"
+          uv run pytest "$PKG_DIR" --cov="$PKG_DIR" --cov-report=xml
+
+      - name: Install build dependencies
+        run: uv sync --dev
+
+      - name: Build package
+        run: uv build --package ${{ steps.info.outputs.pkg_name }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: './dist/*'


### PR DESCRIPTION
Have three different workflows now:

1. General testing workflow which tests all packages from the root of the workspace (this does not do per-package testing, but saves on branching GitHub workflow runners; testing from workspace root also covers all test cases)
2. A new coordinated release workflow which targets any `teamtomo@v*` tags to recursively tag all member packages with the same new version.
3. A release/deployment workflow for all package which will trigger on `<package name>@v*` which first tests that specific package, then builds and releases it.

Should simplify things moving forward, and not consume the free GitHub runner action time during months with high commit/release volumes.