### PR TITLE
add citation file and script to find contributors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,9 +9,21 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.18405652
 authors:
+  - given-names: Benjamin
+    family-names: Barad
+    alias: bbarad
+    affiliation: Oregon Health & Science University
+  - given-names: Ray
+    family-names: Berkeley
+    alias: ray-berkeley
+    affiliation: Scripps Research
   - given-names: Yakau
     family-names: Bubnou
     alias: ybubnov
+  - given-names: Genevieve
+    family-names: Buckley
+    alias: GenevieveBuckley
+    affiliation: Monash University
   - given-names: Alister
     family-names: Burt
     alias: alisterburt
@@ -20,34 +32,137 @@ authors:
     alias: McHaillet
     affiliation: Hubrecht Institute
     orcid: "https://orcid.org/0000-0001-7231-7742"
+  - given-names: Oscar
+    family-names: Despard
+    alias: odespard
+    affiliation: MRC Laboratory of Molecular Biology
+  - given-names: Eric
+    family-names: Deveaud
+    alias: EricDeveaud
+    affiliation: Institut Pasteur
   - given-names: Josh
     family-names: Dickerson
     alias: jdickerson95
   - given-names: Johannes
     family-names: Elferich
     alias: jojoelfe
+  - given-names: Utz
+    family-names: Ermel
+    alias: uermel
+  - given-names: Ryan
+    family-names: Feathers
+    alias: ryanfeathers
   - given-names: Chloe
     family-names: Fisher
     alias: chlofisher
+  - given-names: Lorenzo
+    family-names: Gaifas
+    alias: brisvag
+    affiliation: napari
+  - given-names: Guillaume
+    family-names: Gaullier
+    alias: Guillawme
+    affiliation: Uppsala University
   - given-names: Matthew
     family-names: Giammar
     alias: mgiammar
     affiliation: University of California, Berkeley
+  - given-names: Miles
+    family-names: Graham
+    alias: milesagraham
+  - given-names: Kabilar
+    family-names: Gunalan
+    alias: kabilar
+    affiliation: MIT
+  - given-names: John
+    family-names: Heumann
+    alias: jmheumann
+  - given-names: Thomas
+    family-names: Hoffmann
+    alias: ThomasHoffmann77
+    affiliation: EMBL
+  - given-names: James
+    family-names: Hooker
+    alias: jahooker
+    affiliation: MRC LMB
+  - given-names: Mikel
+    family-names: Izeta
+    alias: ratolon
+    affiliation: CNB-CSIC
+  - given-names: Huw
+    family-names: Jenkins
+    alias: huwjenkins
+  - given-names: Daniel
+    family-names: Ji
+    alias: daniel-ji
+  - given-names: Brady
+    family-names: Johnston
+    alias: BradyAJohnston
+    affiliation: Freelance scientific animator & developer.
+  - given-names: Diyor
+    family-names: Khayrutdinov
+    alias: dijor0310
   - given-names: Viacheslav
     family-names: Kralin
     alias: reddismorr
+  - given-names: Lorenz
+    family-names: Lamm
+    alias: LorenzLamm
+  - given-names: Hanjin
+    family-names: Liu
+    alias: hanjinliu
+  - given-names: Alan R
+    family-names: Lowe
+    alias: quantumjot
   - given-names: Dennis J.
     family-names: Michalak
     alias: dmichalak
+  - given-names: Braxton
+    family-names: Owens
+    alias: braxtonowens
+  - given-names: Gonzalo
+    family-names: Peña-Castellanos
+    alias: goanpeca
+  - given-names: Stephen
+    family-names: Riggs
+    alias: stephen-riggs
+  - given-names: Ricardo
+    family-names: Righetto
+    alias: rdrighetto
   - given-names: Spencer J
     family-names: Rothfuss
     alias: sjrothfuss
     affiliation: Vanderbilt University
+  - given-names: Andreas
+    family-names: Schenk
+    alias: andschenk
+    affiliation: Novartis Institutes for BioMedical Research
   - given-names: Pranav NM
     family-names: Shah
     alias: shahpnmlab
-  - given-names: Philippe
-    family-names: Van der Stappen
+  - given-names: Philippe Van der
+    family-names: Stappen
     alias: Phaips
+  - given-names: Davide
+    family-names: Torre
+    alias: davidetorre99
+  - given-names: Moritz
+    family-names: Wachsmuth-Melm
+    alias: MoritzWM
+  - given-names: Kevin
+    family-names: Yamauchi
+    alias: kevinyamauchi
+    affiliation: Iber Lab - ETH Zürich
+  - alias: alexjnoble
+  - alias: amineuron
+    orcid: "https://orcid.org/0000-0001-9480-5915"
   - alias: aysecanuenal
+  - alias: cormsby626
+  - alias: EuanPyle
+  - given-names: HanyiZhang
+    alias: Hanyi11
+  - alias: MrCurtis
+  - alias: rezaparaancryoem
   - alias: rsanchezgarc
+  - alias: sumslogs
+  - alias: vschwarze

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,9 @@
 cff-version: 1.2.0
-title: teamtomo
+title: "teamtomo: modular Python packages for cryo-EM and cryo-ET"
 message: "If you use this software, please cite it as below."
 type: software
-repository-code: "https://github.com/teamtomo/teamtomo"
-url: "https://teamtomo.org"
+repository-code: https://github.com/teamtomo/teamtomo
+url: https://teamtomo.org
 license: BSD-3-Clause
 identifiers:
   - type: doi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,53 @@
+cff-version: 1.2.0
+title: teamtomo
+message: "If you use this software, please cite it as below."
+type: software
+repository-code: "https://github.com/teamtomo/teamtomo"
+url: "https://teamtomo.org"
+license: BSD-3-Clause
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.18405652
+authors:
+  - given-names: Yakau
+    family-names: Bubnou
+    alias: ybubnov
+  - given-names: Alister
+    family-names: Burt
+    alias: alisterburt
+  - given-names: Marten
+    family-names: Chaillet
+    alias: McHaillet
+    affiliation: Hubrecht Institute
+    orcid: "https://orcid.org/0000-0001-7231-7742"
+  - given-names: Josh
+    family-names: Dickerson
+    alias: jdickerson95
+  - given-names: Johannes
+    family-names: Elferich
+    alias: jojoelfe
+  - given-names: Chloe
+    family-names: Fisher
+    alias: chlofisher
+  - given-names: Matthew
+    family-names: Giammar
+    alias: mgiammar
+    affiliation: University of California, Berkeley
+  - given-names: Viacheslav
+    family-names: Kralin
+    alias: reddismorr
+  - given-names: Dennis J.
+    family-names: Michalak
+    alias: dmichalak
+  - given-names: Spencer J
+    family-names: Rothfuss
+    alias: sjrothfuss
+    affiliation: Vanderbilt University
+  - given-names: Pranav NM
+    family-names: Shah
+    alias: shahpnmlab
+  - given-names: Philippe
+    family-names: Van der Stappen
+    alias: Phaips
+  - alias: aysecanuenal
+  - alias: rsanchezgarc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TeamTomo
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18405652.svg)](https://doi.org/10.5281/zenodo.18405652)
+
 TeamTomo is a set of modular Python package for cryo-EM and cryo-ET for the modern scientific computing environment.
 This unified repository contains most of the core TeamTomo data processing functionality under a single umbrella for better maintainability and cross-package development.
 

--- a/scripts/update_citation_authors.py
+++ b/scripts/update_citation_authors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Update the authors list in CITATION.cff from GitHub contributor data.
 
-Fetches contributors from all repos listed in REPOS below, enriches each
+Fetches contributors from all public repos in the teamtomo org, enriches each
 entry with name, affiliation, and ORCID (from GitHub social accounts), sorts
 alphabetically by family name (alias-only contributors go to the bottom),
 then rewrites the authors section of CITATION.cff.
@@ -26,35 +26,6 @@ CITATION_FILE = REPO_ROOT / "CITATION.cff"
 
 BOT_LOGINS = {"actions-user", "dependabot", "dependabot[bot]", "github-actions[bot]"}
 
-REPOS = [
-    "teamtomo",
-    # Primitives packages
-    "torch-fourier-slice",
-    "torch-fourier-rescale",
-    "torch-fourier-shift",
-    "torch-ctf",
-    "torch-fourier-filter",
-    "torch-fourier-shell-correlation",
-    "torch-image-interpolation",
-    "torch-transform-image",
-    "torch-cubic-spline-grids",
-    "torch-subpixel-crop",
-    "torch-find-peaks",
-    "torch-grid-utils",
-    "torch-so3",
-    "torch-affine-utils",
-    "torch-tilt-series",
-    # Algorithms packages
-    "torch-2dtm",
-    "torch-tiltxcorr",
-    "torch-refine-tilt-axis-angle",
-    "torch-cryoeraser",
-    "torch-segment-fiducials-2d",
-    "torch-segment-tomogram-boundaries",
-    "torch-motion-correction",
-    "torch-ctf-estimation",
-]
-
 
 def github_get(path: str, token: str | None = None) -> list | dict:
     url = f"{GITHUB_API}{path}"
@@ -65,23 +36,26 @@ def github_get(path: str, token: str | None = None) -> list | dict:
     if token:
         req.add_header("Authorization", f"Bearer {token}")
     with urllib.request.urlopen(req) as resp:
-        return json.loads(resp.read().decode())
+        body = resp.read().decode()
+        return json.loads(body) if body.strip() else []
 
 
 def get_contributors(token: str | None = None) -> set[str]:
-    """Return the set of contributor logins across all repos in REPOS."""
+    """Return unique contributor logins across all public repos in the org."""
+    repos = github_get(f"/orgs/{ORG}/repos?per_page=100&type=public", token)
     logins: set[str] = set()
-    for repo in REPOS:
+    for repo in repos:
         try:
             contribs = github_get(
-                f"/repos/{ORG}/{repo}/contributors?per_page=100&anon=false",
+                f"/repos/{ORG}/{repo['name']}/contributors?per_page=100&anon=false",
                 token,
             )
-            for c in contribs:
-                if c.get("type") == "User" and c["login"] not in BOT_LOGINS:
-                    logins.add(c["login"])
-        except urllib.error.HTTPError as e:
-            print(f"  Warning: could not fetch contributors for {repo}: {e}")
+            if isinstance(contribs, list):
+                for c in contribs:
+                    if c.get("type") == "User" and c["login"] not in BOT_LOGINS:
+                        logins.add(c["login"])
+        except (urllib.error.HTTPError, ValueError) as e:
+            print(f"  Warning: could not fetch contributors for {repo['name']}: {e}")
     return logins
 
 
@@ -145,7 +119,7 @@ def update_citation_authors(author_blocks: list[str]) -> None:
 def main() -> None:
     token = os.environ.get("GITHUB_TOKEN")
 
-    print(f"Fetching contributors across {len(REPOS)} repos...")
+    print(f"Fetching contributors across all {ORG} repos...")
     logins = get_contributors(token)
     print(f"Found {len(logins)} contributors\n")
 

--- a/scripts/update_citation_authors.py
+++ b/scripts/update_citation_authors.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Update the authors list in CITATION.cff from GitHub contributor data.
+
+Fetches contributors from all repos listed in REPOS below, enriches each
+entry with name, affiliation, and ORCID (from GitHub social accounts), sorts
+alphabetically by family name (alias-only contributors go to the bottom),
+then rewrites the authors section of CITATION.cff.
+
+Usage:
+    python scripts/update_citation_authors.py
+
+Set the GITHUB_TOKEN environment variable to avoid rate limiting.
+"""
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GITHUB_API = "https://api.github.com"
+ORG = "teamtomo"
+REPO_ROOT = Path(__file__).parent.parent
+CITATION_FILE = REPO_ROOT / "CITATION.cff"
+
+BOT_LOGINS = {"actions-user", "dependabot", "dependabot[bot]", "github-actions[bot]"}
+
+REPOS = [
+    "teamtomo",
+    # Primitives packages
+    "torch-fourier-slice",
+    "torch-fourier-rescale",
+    "torch-fourier-shift",
+    "torch-ctf",
+    "torch-fourier-filter",
+    "torch-fourier-shell-correlation",
+    "torch-image-interpolation",
+    "torch-transform-image",
+    "torch-cubic-spline-grids",
+    "torch-subpixel-crop",
+    "torch-find-peaks",
+    "torch-grid-utils",
+    "torch-so3",
+    "torch-affine-utils",
+    "torch-tilt-series",
+    # Algorithms packages
+    "torch-2dtm",
+    "torch-tiltxcorr",
+    "torch-refine-tilt-axis-angle",
+    "torch-cryoeraser",
+    "torch-segment-fiducials-2d",
+    "torch-segment-tomogram-boundaries",
+    "torch-motion-correction",
+    "torch-ctf-estimation",
+]
+
+
+def github_get(path: str, token: str | None = None) -> list | dict:
+    url = f"{GITHUB_API}{path}"
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "teamtomo-citation-updater")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def get_contributors(token: str | None = None) -> set[str]:
+    """Return the set of contributor logins across all repos in REPOS."""
+    logins: set[str] = set()
+    for repo in REPOS:
+        try:
+            contribs = github_get(
+                f"/repos/{ORG}/{repo}/contributors?per_page=100&anon=false",
+                token,
+            )
+            for c in contribs:
+                if c.get("type") == "User" and c["login"] not in BOT_LOGINS:
+                    logins.add(c["login"])
+        except urllib.error.HTTPError as e:
+            print(f"  Warning: could not fetch contributors for {repo}: {e}")
+    return logins
+
+
+def get_orcid(login: str, token: str | None = None) -> str | None:
+    """Return the ORCID URL from a user's GitHub social accounts, if present."""
+    accounts = github_get(f"/users/{login}/social_accounts", token)
+    for account in accounts:
+        url = account.get("url", "")
+        if "orcid.org" in url:
+            return url
+    return None
+
+
+def split_name(full_name: str) -> tuple[str | None, str | None]:
+    """Split a full name into (given_names, family_name) on the last space."""
+    parts = full_name.strip().split()
+    if not parts:
+        return None, None
+    if len(parts) == 1:
+        return parts[0], None
+    return " ".join(parts[:-1]), parts[-1]
+
+
+def format_author_entry(info: dict, orcid: str | None) -> str:
+    """Return a CITATION.cff author YAML block."""
+    login = info["login"]
+    full_name = (info.get("name") or "").strip()
+    company = (info.get("company") or "").strip().lstrip("@").strip() or None
+
+    given, family = split_name(full_name)
+
+    fields: list[tuple[str, str]] = []
+    if given:
+        fields.append(("given-names", given))
+    if family:
+        fields.append(("family-names", family))
+    fields.append(("alias", login))
+    if company:
+        fields.append(("affiliation", company))
+    if orcid:
+        fields.append(("orcid", f'"{orcid}"'))
+
+    lines = [f"  - {fields[0][0]}: {fields[0][1]}"]
+    for key, value in fields[1:]:
+        lines.append(f"    {key}: {value}")
+    return "\n".join(lines)
+
+
+def update_citation_authors(author_blocks: list[str]) -> None:
+    """Replace the authors section in CITATION.cff, preserving everything else."""
+    content = CITATION_FILE.read_text()
+    match = re.search(r"^authors:.*$", content, re.MULTILINE)
+    if not match:
+        raise ValueError("Could not find 'authors:' section in CITATION.cff")
+    preamble = content[: match.start()]
+    CITATION_FILE.write_text(
+        preamble + "authors:\n" + "\n".join(author_blocks) + "\n"
+    )
+
+
+def main() -> None:
+    token = os.environ.get("GITHUB_TOKEN")
+
+    print(f"Fetching contributors across {len(REPOS)} repos...")
+    logins = get_contributors(token)
+    print(f"Found {len(logins)} contributors\n")
+
+    authors: list[tuple[dict, str | None]] = []
+    for login in sorted(logins):
+        print(f"  Fetching {login}...")
+        info = github_get(f"/users/{login}", token)
+        orcid = get_orcid(login, token)
+        authors.append((info, orcid))
+
+    # Sort alphabetically by family name; alias-only entries go to the bottom
+    def sort_key(entry: tuple[dict, str | None]) -> tuple[int, str]:
+        info, _ = entry
+        _, family = split_name((info.get("name") or "").strip())
+        if family:
+            return (0, family.lower())
+        return (1, info["login"].lower())
+
+    authors.sort(key=sort_key)
+    author_blocks = [format_author_entry(info, orcid) for info, orcid in authors]
+
+    update_citation_authors(author_blocks)
+    print(f"\nUpdated {CITATION_FILE.name} with {len(author_blocks)} authors.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
adresses #29

This adds a CITATION.cff file. This is the default place where zenodo grabs authors from. It should update once a new version is released.

I added a script that assembles the authors by looking at contributors to:
* the teamtomo repo
* and all the repo's listed in notes/migration-progress.md (sorting by contributions might be more fair though)

It then:
1. fetches names, affiliation, and orcid from the GitHub profile if they are available
2. sorts alphabetically by last name and puts github tags at the bottom


I am still unsure about this:
- [x] does the author list make sense? or should it be teamtomo contributors organisation wide?