### PR TITLE
fix(torch-fourier-rescale): preserve mean when source and target have different parity

### DIFF
--- a/packages/primitives/torch-fourier-rescale/src/torch_fourier_rescale/utils.py
+++ b/packages/primitives/torch-fourier-rescale/src/torch_fourier_rescale/utils.py
@@ -88,13 +88,20 @@ def fourier_rescale_dimension(
             pad_spec = [0, 0] * (dft.ndim - dim - 1) + [0, pad_size] + [0, 0] * dim
             return F.pad(dft, pad_spec, mode="constant", value=0)
     else:
-        # For regular FFT dimensions (full frequency spectrum)
+        # For regular FFT dimensions (full frequency spectrum), the DC bin of
+        # an fftshift'd array of size N is at index `N // 2` and the upstream
+        # `torch.fft.ifftshift` expects it there too. The crop / pad must
+        # therefore leave the DC at position `target // 2` of the new array,
+        # not at `(source - target) // 2` from the start — those differ when
+        # source and target have different parity (e.g. even source, odd
+        # target). Using `total_crop // 2` (or `total_pad // 2`) silently
+        # placed the DC at the wrong index in those cases, sending it to a
+        # high-frequency bin after ifftshift and zeroing the mean of the
+        # reconstructed image.
         if target_dim_length < source_dim_length:
-            # Crop: Remove frequencies symmetrically from both ends
-            total_crop = current_dft_size - target_dim_length
-            crop_start = total_crop // 2
-            crop_end = total_crop - crop_start
-
+            # Crop: keep central target_dim_length samples around the DC.
+            crop_start = current_dft_size // 2 - target_dim_length // 2
+            crop_end = current_dft_size - target_dim_length - crop_start
             indices = [slice(None)] * dft.ndim
             if crop_end > 0:
                 indices[dim] = slice(crop_start, -crop_end)
@@ -102,16 +109,13 @@ def fourier_rescale_dimension(
                 indices[dim] = slice(crop_start, None)
             return dft[tuple(indices)]
         else:
-            # Pad: Add zeros symmetrically
-            total_pad = target_dim_length - current_dft_size
-            pad_start = total_pad // 2
-            pad_end = total_pad - pad_start
+            # Pad: zero-pad symmetrically so the original DC ends up at
+            # target // 2 of the padded array.
+            pad_start = target_dim_length // 2 - current_dft_size // 2
+            pad_end = (target_dim_length - current_dft_size) - pad_start
 
-            # Adjust for odd source size
-            if source_dim_length % 2 == 1:
-                pad_end = pad_end - 1
-
-            # Create padding specification (PyTorch F.pad expects pairs from last to first dim)
+            # PyTorch F.pad expects [pad_left, pad_right] pairs from the
+            # last dim to the first, hence the leading zero pairs.
             pad_spec = [0, 0] * (dft.ndim - dim - 1)
             pad_spec.extend([pad_start, pad_end])
             pad_spec.extend([0, 0] * dim)

--- a/packages/primitives/torch-fourier-rescale/src/torch_fourier_rescale/utils.py
+++ b/packages/primitives/torch-fourier-rescale/src/torch_fourier_rescale/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for Fourier rescaling operations."""
+
 import numbers
 
 import numpy as np
@@ -88,16 +90,12 @@ def fourier_rescale_dimension(
             pad_spec = [0, 0] * (dft.ndim - dim - 1) + [0, pad_size] + [0, 0] * dim
             return F.pad(dft, pad_spec, mode="constant", value=0)
     else:
-        # For regular FFT dimensions (full frequency spectrum), the DC bin of
-        # an fftshift'd array of size N is at index `N // 2` and the upstream
-        # `torch.fft.ifftshift` expects it there too. The crop / pad must
-        # therefore leave the DC at position `target // 2` of the new array,
-        # not at `(source - target) // 2` from the start — those differ when
-        # source and target have different parity (e.g. even source, odd
-        # target). Using `total_crop // 2` (or `total_pad // 2`) silently
-        # placed the DC at the wrong index in those cases, sending it to a
-        # high-frequency bin after ifftshift and zeroing the mean of the
-        # reconstructed image.
+        # For regular FFT dimensions (full frequency spectrum)
+        # NOTE: DC bin for fftshift'd array expected at index `N // 2`. Cropping and
+        #       padding must preserve position in new array (position `target // 2`).
+        #       New code here fixes previous bug where DC was placed at
+        #       `(source - target) // 2` from start which is wrong when source and
+        #       target have different parity.
         if target_dim_length < source_dim_length:
             # Crop: keep central target_dim_length samples around the DC.
             crop_start = current_dft_size // 2 - target_dim_length // 2

--- a/packages/primitives/torch-fourier-rescale/tests/test_torch_fourier_rescale.py
+++ b/packages/primitives/torch-fourier-rescale/tests/test_torch_fourier_rescale.py
@@ -1,62 +1,61 @@
+import numbers
+
 import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F
 
-from torch_fourier_rescale import fourier_rescale_2d, fourier_rescale_3d
+from torch_fourier_rescale import (
+    fourier_rescale_2d,
+    fourier_rescale_3d,
+    fourier_rescale_rfft_2d,
+    fourier_rescale_rfft_3d,
+)
 
 
 def test_fourier_upscale_2d(circle):
-    rescaled, new_spacing = fourier_rescale_2d(
-        image=circle, source_spacing=1, target_spacing=0.5
-    )
+    rescaled, _ = fourier_rescale_2d(image=circle, source_spacing=1, target_spacing=0.5)
     assert tuple(circle.shape) == (28, 28)
     assert tuple(rescaled.shape) == (56, 56)
 
     # test upscale with uneven image
-    rescaled, new_spacing = fourier_rescale_2d(
+    rescaled, _ = fourier_rescale_2d(
         image=F.pad(circle, (0, 1, 0, 1)), source_spacing=1, target_spacing=0.5
     )
     assert tuple(rescaled.shape) == (58, 58)
 
 
 def test_fourier_downscale_2d(circle):
-    rescaled, new_spacing = fourier_rescale_2d(
-        image=circle, source_spacing=1, target_spacing=2
-    )
+    rescaled, _ = fourier_rescale_2d(image=circle, source_spacing=1, target_spacing=2)
     assert tuple(circle.shape) == (28, 28)
     assert tuple(rescaled.shape) == (14, 14)
 
     # test downscale with uneven image
-    rescaled, new_spacing = fourier_rescale_2d(
+    rescaled, _ = fourier_rescale_2d(
         image=F.pad(circle, (0, 1, 0, 1)), source_spacing=1, target_spacing=2
     )
     assert tuple(rescaled.shape) == (14, 14)
 
 
 def test_fourier_upscale_3d(sphere):
-    rescaled, new_spacing = fourier_rescale_3d(
-        image=sphere, source_spacing=1, target_spacing=0.5
-    )
+    rescaled, _ = fourier_rescale_3d(image=sphere, source_spacing=1, target_spacing=0.5)
     assert tuple(sphere.shape) == (28, 28, 28)
     assert tuple(rescaled.shape) == (56, 56, 56)
 
     # test upscale with uneven box
-    rescaled, new_spacing = fourier_rescale_3d(
+    rescaled, _ = fourier_rescale_3d(
         image=F.pad(sphere, (0, 1, 0, 1, 0, 1)), source_spacing=1, target_spacing=0.5
     )
     assert tuple(rescaled.shape) == (58, 58, 58)
 
 
 def test_fourier_downscale_3d(sphere):
-    rescaled, new_spacing = fourier_rescale_3d(
-        image=sphere, source_spacing=1, target_spacing=2
-    )
+    rescaled, _ = fourier_rescale_3d(image=sphere, source_spacing=1, target_spacing=2)
     assert tuple(sphere.shape) == (28, 28, 28)
     assert tuple(rescaled.shape) == (14, 14, 14)
 
     # test downscale with uneven box
-    rescaled, new_spacing = fourier_rescale_3d(
+    rescaled, _ = fourier_rescale_3d(
         image=F.pad(sphere, (0, 1, 0, 1, 0, 1)), source_spacing=1, target_spacing=2
     )
     assert tuple(rescaled.shape) == (14, 14, 14)
@@ -64,12 +63,12 @@ def test_fourier_downscale_3d(sphere):
 
 @pytest.mark.parametrize("spacing", [0.5, 2.0])
 def test_fourier_rescale_2d_mean(circle, spacing):
-    rescaled, new_spacing = fourier_rescale_2d(
+    rescaled, _ = fourier_rescale_2d(
         image=circle, source_spacing=1, target_spacing=spacing
     )
     assert rescaled.mean() == pytest.approx(circle.mean())
 
-    rescaled, new_spacing = fourier_rescale_2d(
+    rescaled, _ = fourier_rescale_2d(
         image=circle, source_spacing=1, target_spacing=spacing, preserve_mean=False
     )
     assert rescaled.mean() != pytest.approx(circle.mean())
@@ -77,12 +76,12 @@ def test_fourier_rescale_2d_mean(circle, spacing):
 
 @pytest.mark.parametrize("spacing", [0.5, 2.0])
 def test_fourier_rescale_3d_mean(sphere, spacing):
-    rescaled, new_spacing = fourier_rescale_3d(
+    rescaled, _ = fourier_rescale_3d(
         image=sphere, source_spacing=1, target_spacing=spacing
     )
     assert rescaled.mean() == pytest.approx(sphere.mean())
 
-    rescaled, new_spacing = fourier_rescale_3d(
+    rescaled, _ = fourier_rescale_3d(
         image=sphere, source_spacing=1, target_spacing=spacing, preserve_mean=False
     )
     assert rescaled.mean() != pytest.approx(sphere.mean())
@@ -146,10 +145,10 @@ def test_fourier_rescale_3d_preserves_mean_for_all_parities(source_shape, target
 )
 def test_pixel_spacing_scalar_dtypes(dtype, circle, sphere):
     # Smoke test - just verify functions don't crash with different scalar dtypes
-    if dtype == int:
+    if isinstance(dtype, type) and issubclass(dtype, numbers.Number):
         source_spacing = 1
         target_spacing = 2
-    elif dtype == float:
+    elif dtype in [int, float]:
         source_spacing = 1.0
         target_spacing = 0.5
     elif dtype in [np.float32, np.float64]:
@@ -294,3 +293,86 @@ def test_preserve_mean_with_target_shape_2d(circle):
         image=circle, target_shape=(56, 56), preserve_mean=False
     )
     assert rescaled_no_preserve.mean() != pytest.approx(circle.mean())
+
+
+# Tests for fourier_rescale_rfft_2d and fourier_rescale_rfft_3d with even/odd arrays
+@pytest.mark.parametrize(
+    "source_shape,target_shape",
+    [
+        # even -> even
+        ((16, 16), (8, 8)),
+        # even -> odd (the common cryo-EM case)
+        ((16, 16), (7, 7)),
+        # odd -> even
+        ((15, 15), (8, 8)),
+        # odd -> odd
+        ((15, 15), (7, 7)),
+        # even -> odd upscale
+        ((8, 8), (15, 15)),
+        # odd -> even upscale
+        ((7, 7), (16, 16)),
+    ],
+)
+def test_fourier_rescale_rfft_2d_with_even_odd_arrays(source_shape, target_shape):
+    """Test fourier_rescale_rfft_2d with pre-computed rfft for even/odd sizes."""
+    torch.manual_seed(0)
+    image = torch.full(source_shape, 5.0) + 0.01 * torch.randn(source_shape)
+
+    # Compute rfft as done internally in fourier_rescale_2d
+    image_shifted = torch.fft.fftshift(image, dim=(-2, -1))
+    dft = torch.fft.rfftn(image_shifted, dim=(-2, -1))
+    dft_shifted = torch.fft.fftshift(dft, dim=(-2,))
+
+    # Call the rfft function directly
+    dft_rescaled = fourier_rescale_rfft_2d(
+        dft=dft_shifted,
+        image_shape=source_shape,
+        target_shape=target_shape,
+    )
+
+    # Verify output shape is correct
+    # For rfft, the last dimension should be target_shape[-1] // 2 + 1
+    expected_rfft_width = target_shape[-1] // 2 + 1
+    expected_shape = (target_shape[-2], expected_rfft_width)
+    assert dft_rescaled.shape[-2:] == expected_shape
+
+
+@pytest.mark.parametrize(
+    "source_shape,target_shape",
+    [
+        # even -> even
+        ((16, 16, 16), (8, 8, 8)),
+        # even -> odd
+        ((16, 16, 16), (7, 7, 7)),
+        # odd -> even
+        ((15, 15, 15), (8, 8, 8)),
+        # odd -> odd
+        ((15, 15, 15), (7, 7, 7)),
+        # upscale: odd -> even
+        ((7, 7, 7), (16, 16, 16)),
+        # upscale: even -> odd
+        ((8, 8, 8), (15, 15, 15)),
+    ],
+)
+def test_fourier_rescale_rfft_3d_with_even_odd_arrays(source_shape, target_shape):
+    """Test fourier_rescale_rfft_3d with pre-computed rfft for even/odd sizes."""
+    torch.manual_seed(0)
+    image = torch.full(source_shape, 5.0) + 0.01 * torch.randn(source_shape)
+
+    # Compute rfft as done internally in fourier_rescale_3d
+    image_shifted = torch.fft.fftshift(image, dim=(-3, -2, -1))
+    dft = torch.fft.rfftn(image_shifted, dim=(-3, -2, -1))
+    dft_shifted = torch.fft.fftshift(dft, dim=(-3, -2))
+
+    # Call the rfft function directly
+    dft_rescaled = fourier_rescale_rfft_3d(
+        dft=dft_shifted,
+        image_shape=source_shape,
+        target_shape=target_shape,
+    )
+
+    # Verify output shape is correct
+    # For rfft, the last dimension should be target_shape[-1] // 2 + 1
+    expected_rfft_width = target_shape[-1] // 2 + 1
+    expected_shape = (target_shape[-3], target_shape[-2], expected_rfft_width)
+    assert dft_rescaled.shape[-3:] == expected_shape

--- a/packages/primitives/torch-fourier-rescale/tests/test_torch_fourier_rescale.py
+++ b/packages/primitives/torch-fourier-rescale/tests/test_torch_fourier_rescale.py
@@ -88,6 +88,59 @@ def test_fourier_rescale_3d_mean(sphere, spacing):
     assert rescaled.mean() != pytest.approx(sphere.mean())
 
 
+# Cover every parity combination of source / target / direction. Pre-fix, the
+# 2D fast path collapsed the mean to ~0 when source and target had different
+# parity (e.g. even source, odd target — the common case when rescaling a
+# 4096^2 image to a non-power-of-two spacing). Regression test ensures the
+# fast path keeps the DC component in the correct frequency bin for every
+# parity combination.
+@pytest.mark.parametrize(
+    "source_shape,target_shape",
+    [
+        # 2D downscale: even -> even (works pre-fix)
+        ((16, 16), (8, 8)),
+        # 2D downscale: even -> odd (BROKEN pre-fix)
+        ((16, 16), (7, 7)),
+        # 2D downscale: odd -> even
+        ((15, 15), (8, 8)),
+        # 2D downscale: odd -> odd
+        ((15, 15), (7, 7)),
+        # 2D upscale: even -> odd
+        ((8, 8), (15, 15)),
+        # 2D upscale: odd -> even
+        ((7, 7), (16, 16)),
+        # Asymmetric source/target (cryo-EM tilt-stack-like aspect ratio)
+        ((4096, 4096), (609, 609)),
+    ],
+)
+def test_fourier_rescale_2d_preserves_mean_for_all_parities(source_shape, target_shape):
+    torch.manual_seed(0)
+    image = torch.full(source_shape, 5.0) + 0.01 * torch.randn(source_shape)
+    rescaled, _ = fourier_rescale_2d(
+        image=image, target_shape=target_shape, preserve_mean=True
+    )
+    assert tuple(rescaled.shape) == target_shape
+    assert rescaled.mean().item() == pytest.approx(image.mean().item(), abs=1e-3)
+
+
+@pytest.mark.parametrize(
+    "source_shape,target_shape",
+    [
+        ((16, 16, 16), (7, 7, 7)),
+        ((15, 15, 15), (8, 8, 8)),
+        ((7, 7, 7), (16, 16, 16)),
+    ],
+)
+def test_fourier_rescale_3d_preserves_mean_for_all_parities(source_shape, target_shape):
+    torch.manual_seed(0)
+    image = torch.full(source_shape, 5.0) + 0.01 * torch.randn(source_shape)
+    rescaled, _ = fourier_rescale_3d(
+        image=image, target_shape=target_shape, preserve_mean=True
+    )
+    assert tuple(rescaled.shape) == target_shape
+    assert rescaled.mean().item() == pytest.approx(image.mean().item(), abs=1e-3)
+
+
 @pytest.mark.parametrize(
     "dtype", [int, float, np.float32, np.float64, torch.float32, torch.float64]
 )


### PR DESCRIPTION
## Summary

`fourier_rescale_2d` / `fourier_rescale_3d` with `preserve_mean=True` (the default) silently collapse the output mean to ~0 instead of preserving the input mean when the source and target spatial dimensions have different parity (e.g. even source, odd target).

## Reproducer

```python
import torch
from torch_fourier_rescale import fourier_rescale_2d

image = torch.full((16, 16), 5.0)
out, _ = fourier_rescale_2d(image, target_shape=(7, 7), preserve_mean=True)
print(out.mean().item())  # actual: ~0.0    expected: ~5.0
```

I hit this in the wild in a cryo-EM tilt-stack prebin: 4096² at 1.49 Å rescaled to 10 Å (target 609², odd) — the resulting "image" had mean ≈ -3e-4 instead of the input mean of ~0.4, which is dramatically broken.

## Root cause

In `fourier_rescale_dimension` (full-FFT path), the crop math was:

```python
total_crop = current_dft_size - target_dim_length
crop_start = total_crop // 2  # ← placement is wrong when parity differs
```

That puts the DC bin at `source // 2 - crop_start` of the cropped array. The caller then applies `torch.fft.ifftshift(..., dim=-2)` which expects the DC at index `target // 2`. The two positions coincide when source and target share parity, but differ by 1 when they don't — and a 1-bin offset in the unshifted DFT sends the DC to a high-frequency bin, so the reconstructed image has near-zero mean instead of the input mean.

The padding path had the matching bug, papered over with an ad-hoc `if source_dim_length % 2 == 1: pad_end -= 1` workaround that gives the wrong total padding when target is odd.

## Fix

Place the DC at `target // 2` of the new array in both crop and pad paths:

```python
crop_start = current_dft_size // 2 - target_dim_length // 2
pad_start  = target_dim_length // 2 - current_dft_size // 2
```

Symmetric, parity-agnostic, and trivially correct against the ifftshift the caller applies right after. Same one-liner for both directions; the ad-hoc odd-source workaround in the pad path can go away.

## Test plan
- [x] Added `test_fourier_rescale_{2,3}d_preserves_mean_for_all_parities` covering every even/odd source × target combo plus the 4096→609 cryo-EM case
- [x] Verified the new tests fail on `main` (3 fail) and pass with the fix (10/10 pass)
- [x] All 21 pre-existing tests in `test_torch_fourier_rescale.py` still pass (31/31 total)
- [x] No API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)