### PR TITLE
Package resolution fix to deploy meta-package `teamtomo` to PyPI

### DIFF
--- a/.github/scripts/get_all_packages.py
+++ b/.github/scripts/get_all_packages.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 # Define workspace member glob patterns (same as pyproject.toml)
 PATTERNS = [
+    "pyproject.toml",  # root meta-package (teamtomo)
     "packages/io/*/pyproject.toml",
     "packages/primitives/*/pyproject.toml",
     "packages/algorithms/*/pyproject.toml",


### PR DESCRIPTION
Should enable easy `pip install teamtomo` to gather all packages across the org