### PR TITLE
feat(torch-fourier-filter): add optional frequency_grid_px

### DIFF
--- a/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/envelopes.py
+++ b/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/envelopes.py
@@ -5,14 +5,35 @@ from torch_ctf import calculate_relativistic_electron_wavelength
 from torch_grid_utils.fftfreq_grid import fftfreq_grid
 
 
+def _b_envelope(frequency_grid_px: torch.Tensor, B: float) -> torch.Tensor:
+    """
+    Compute a B-factor envelope from a pre-computed frequency grid.
+
+    Parameters
+    ----------
+    frequency_grid_px: torch.Tensor
+        Frequency grid in Å⁻¹, e.g.
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+    B: float
+        The B-factor value.
+        Suggested value is 5 A^2 / e-/A^2
+
+    Returns
+    -------
+    torch.Tensor
+        B-factor envelope
+    """
+    divisor = 4  # this is 4 for amplitude, 2 for intensity
+    return torch.exp(-(B * frequency_grid_px**2) / divisor)
+
+
 def b_envelope(
     B: float,
-    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
-    pixel_size: float | None = None,
+    image_shape: tuple[int, int] | tuple[int, int, int],
+    pixel_size: float,
     rfft: bool = True,
     fftshift: bool = False,
     device: torch.device = None,
-    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create a B-factor envelope for a Fourier transform.
@@ -22,64 +43,79 @@ def b_envelope(
     B: float
         The B-factor value.
         Suggested value is 5 A^2 / e-/A^2
-    image_shape: tuple[int, ...] | None
+    image_shape: tuple[int, ...]
         Shape of the real space the dft is from input image.
-        Required when ``frequency_grid_px`` is not provided.
-    pixel_size: float | None
+    pixel_size: float
         The pixel size of the image in Å.
-        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
-        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
-        Ignored when ``frequency_grid_px`` is provided.
     device: torch.device
         Device to place tensors on.
-        Ignored when ``frequency_grid_px`` is provided.
-    frequency_grid_px: torch.Tensor | None
-        Pre-computed frequency grid in Å⁻¹, equivalent to
-        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
-        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
-        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         B-factor envelope
     """
-    if frequency_grid_px is None:
-        if image_shape is None or pixel_size is None:
-            raise ValueError(
-                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
-            )
-        frequency_grid_px = (
-            fftfreq_grid(
-                image_shape=image_shape,
-                rfft=rfft,
-                fftshift=fftshift,
-                norm=True,
-                device=device,
-            )
-            / pixel_size
+    frequency_grid_px = (
+        fftfreq_grid(
+            image_shape=image_shape,
+            rfft=rfft,
+            fftshift=fftshift,
+            norm=True,
+            device=device,
         )
+        / pixel_size
+    )
+    return _b_envelope(frequency_grid_px, B)
 
-    divisor = 4  # this is 4 for amplitude, 2 for intensity
-    b_tensor = torch.exp(-(B * frequency_grid_px**2) / divisor)
-    return b_tensor
+
+def _dose_envelope(
+    frequency_grid_px: torch.Tensor,
+    fluence: float,
+    a: float = 0.245,
+    b: float = -1.665,
+    c: float = 2.81,
+) -> torch.Tensor:
+    """
+    Compute a Grant & Grigorieff (2015) dose envelope from a frequency grid.
+
+    Parameters
+    ----------
+    frequency_grid_px: torch.Tensor
+        Frequency grid in Å⁻¹, e.g.
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+    fluence: float
+        The fluence of the electron beam in e-/A^2.
+    a: float
+        The a parameter of the dose envelope.
+    b: float
+        The b parameter of the dose envelope.
+    c: float
+        The c parameter of the dose envelope.
+
+    Returns
+    -------
+    torch.Tensor
+        Dose envelope
+    """
+    if fluence < c:
+        return torch.ones_like(frequency_grid_px)
+    return torch.exp(-(fluence - c) / (a * torch.pow(frequency_grid_px, b)))
 
 
 def dose_envelope(
     fluence: float,
-    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
-    pixel_size: float | None = None,
+    image_shape: tuple[int, int] | tuple[int, int, int],
+    pixel_size: float,
     rfft: bool = True,
     fftshift: bool = False,
     a: float = 0.245,
     b: float = -1.665,
     c: float = 2.81,
     device: torch.device = None,
-    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create Grant and Grigorieff 2015 dose envelope for a Fourier transform.
@@ -88,18 +124,14 @@ def dose_envelope(
     ----------
     fluence: float
         The fluence of the electron beam in e-/A^2.
-    image_shape: tuple[int, ...] | None
+    image_shape: tuple[int, ...]
         Shape of the real space the dft is from input image.
-        Required when ``frequency_grid_px`` is not provided.
-    pixel_size: float | None
+    pixel_size: float
         The pixel size of the image in Å.
-        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
-        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
-        Ignored when ``frequency_grid_px`` is provided.
     a: float
         The a parameter of the dose envelope.
     b: float
@@ -108,53 +140,81 @@ def dose_envelope(
         The c parameter of the dose envelope.
     device: torch.device
         Device to place tensors on.
-        Ignored when ``frequency_grid_px`` is provided.
-    frequency_grid_px: torch.Tensor | None
-        Pre-computed frequency grid in Å⁻¹, equivalent to
-        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
-        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
-        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         Dose envelope
     """
-    if frequency_grid_px is None:
-        if image_shape is None or pixel_size is None:
-            raise ValueError(
-                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
-            )
-        frequency_grid_px = (
-            fftfreq_grid(
-                image_shape=image_shape,
-                rfft=rfft,
-                fftshift=fftshift,
-                norm=True,
-                device=device,
-            )
-            / pixel_size
+    frequency_grid_px = (
+        fftfreq_grid(
+            image_shape=image_shape,
+            rfft=rfft,
+            fftshift=fftshift,
+            norm=True,
+            device=device,
         )
+        / pixel_size
+    )
+    return _dose_envelope(frequency_grid_px, fluence, a, b, c)
 
-    if fluence < c:
-        fluence_env = torch.ones_like(frequency_grid_px)
-    else:
-        fluence_env = torch.exp(-(fluence - c) / (a * torch.pow(frequency_grid_px, b)))
 
-    return fluence_env
+def _Cs_envelope(
+    frequency_grid_px: torch.Tensor,
+    spherical_aberration: float,  # in mm
+    defocus: float,  # units in microns, positive for underfocus
+    voltage: float = 300,  # in kV
+    alpha: float = 0.005,  # semiangle in mrad
+) -> torch.Tensor:
+    """
+    Compute a Cs envelope from a pre-computed frequency grid.
+
+    Parameters
+    ----------
+    frequency_grid_px: torch.Tensor
+        Frequency grid in Å⁻¹, e.g.
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+    spherical_aberration: float
+        The Cs value in mm
+    defocus: float
+        The defocus value in microns. Positive for underfocus.
+    voltage: float
+        The voltage of the microscope in kV.
+    alpha: float
+        The semiangle in mrad.
+
+    Returns
+    -------
+    torch.Tensor
+        Cs envelope
+    """
+    voltage *= 1e3  # kV -> V
+    _lambda = (
+        calculate_relativistic_electron_wavelength(voltage) * 1e10
+    )  # wavelength meters -> angstroms
+    Cs = spherical_aberration * 1e7  # mm -> angstroms
+    defocus *= 1e4  # microns -> angstroms
+
+    return torch.exp(
+        -(((torch.pi * (alpha / 1000)) / _lambda) ** 2)
+        * (
+            Cs * _lambda**3 * frequency_grid_px**3
+            + _lambda * (defocus) * frequency_grid_px
+        )
+        ** 2
+    )
 
 
 def Cs_envelope(
     spherical_aberration: float,  # in mm
     defocus: float,  # units in microns, positive for underfocus
-    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
-    pixel_size: float | None = None,  # in angstroms
+    image_shape: tuple[int, int] | tuple[int, int, int],
+    pixel_size: float,  # in angstroms
     rfft: bool = True,
     fftshift: bool = False,
     device: torch.device = None,
     voltage: float = 300,  # in kV
     alpha: float = 0.005,  # semiangle in mrad
-    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create a Cs envelope for a Fourier transform.
@@ -165,106 +225,59 @@ def Cs_envelope(
         The Cs value in mm
     defocus: float
         The defocus value in microns. Positive for underfocus.
-    image_shape: tuple[int, ...] | None
+    image_shape: tuple[int, ...]
         Shape of the real space the dft is from input image.
-        Required when ``frequency_grid_px`` is not provided.
-    pixel_size: float | None
+    pixel_size: float
         The pixel size of the image in Å.
-        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
-        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
-        Ignored when ``frequency_grid_px`` is provided.
     device: torch.device
         Device to place tensors on.
-        Ignored when ``frequency_grid_px`` is provided.
     voltage: float
         The voltage of the microscope in kV.
     alpha: float
         The semiangle in mrad.
-    frequency_grid_px: torch.Tensor | None
-        Pre-computed frequency grid in Å⁻¹, equivalent to
-        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
-        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
-        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         Cs envelope
     """
-    if frequency_grid_px is None:
-        if image_shape is None or pixel_size is None:
-            raise ValueError(
-                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
-            )
-        frequency_grid_px = (
-            fftfreq_grid(
-                image_shape=image_shape,
-                rfft=rfft,
-                fftshift=fftshift,
-                norm=True,
-                device=device,
-            )
-            / pixel_size
+    frequency_grid_px = (
+        fftfreq_grid(
+            image_shape=image_shape,
+            rfft=rfft,
+            fftshift=fftshift,
+            norm=True,
+            device=device,
         )
-
-    voltage *= 1e3  # kV -> V
-    _lambda = (
-        calculate_relativistic_electron_wavelength(voltage) * 1e10
-    )  # wavelength meters -> angstroms
-    Cs = spherical_aberration * 1e7  # mm -> angstroms
-    defocus *= 1e4  # microns -> angstroms
-
-    Cs_env = torch.exp(
-        -(((torch.pi * (alpha / 1000)) / _lambda) ** 2)
-        * (
-            Cs * _lambda**3 * frequency_grid_px**3
-            + _lambda * (defocus) * frequency_grid_px
-        )
-        ** 2
+        / pixel_size
+    )
+    return _Cs_envelope(
+        frequency_grid_px, spherical_aberration, defocus, voltage, alpha
     )
 
-    return Cs_env
 
-
-def Cc_envelope(
+def _Cc_envelope(
+    frequency_grid_px: torch.Tensor,
     chromatic_aberration: float,  # in mm
-    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
-    pixel_size: float | None = None,  # in angstroms
-    rfft: bool = True,
-    fftshift: bool = False,
-    device: torch.device = None,
     voltage: float = 300,  # in kV
     energy_spread: float = 0.7,  # in eV
     deltaV_V: float = 0.06e-6,
     deltaI_I: float = 0.01e-6,
-    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
-    Create a Cc envelope for a Fourier transform.
+    Compute a Cc envelope from a pre-computed frequency grid.
 
     Parameters
     ----------
+    frequency_grid_px: torch.Tensor
+        Frequency grid in Å⁻¹, e.g.
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
     chromatic_aberration: float
         The Cc value in mm
-    image_shape: tuple[int, ...] | None
-        Shape of the real space the dft is from input image.
-        Required when ``frequency_grid_px`` is not provided.
-    pixel_size: float | None
-        The pixel size of the image in Å.
-        Required when ``frequency_grid_px`` is not provided.
-    rfft: bool
-        Whether the input is from an rfft (True) or full fft (False).
-        Ignored when ``frequency_grid_px`` is provided.
-    fftshift: bool
-        Whether the input is fftshifted.
-        Ignored when ``frequency_grid_px`` is provided.
-    device: torch.device
-        Device to place tensors on.
-        Ignored when ``frequency_grid_px`` is provided.
     voltage: float
         The voltage of the microscope in kV.
     energy_spread: float
@@ -273,33 +286,12 @@ def Cc_envelope(
         The relative voltage spread.
     deltaI_I: float
         The relative current spread
-    frequency_grid_px: torch.Tensor | None
-        Pre-computed frequency grid in Å⁻¹, equivalent to
-        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
-        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
-        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         Cc envelope
     """
-    if frequency_grid_px is None:
-        if image_shape is None or pixel_size is None:
-            raise ValueError(
-                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
-            )
-        frequency_grid_px = (
-            fftfreq_grid(
-                image_shape=image_shape,
-                rfft=rfft,
-                fftshift=fftshift,
-                norm=True,
-                device=device,
-            )
-            / pixel_size
-        )
-
     voltage *= 1e3  # kV -> V
     _lambda = (
         calculate_relativistic_electron_wavelength(voltage) * 1e10
@@ -309,8 +301,69 @@ def Cc_envelope(
     focus_spread = Cc * (
         ((energy_spread / voltage) ** 2 + deltaV_V**2 + (2 * deltaI_I) ** 2) ** 0.5
     )
-    Cc_env = torch.exp(
+    return torch.exp(
         -0.5 * ((torch.pi * _lambda * focus_spread * (frequency_grid_px) ** 2) ** 2)
     )
 
-    return Cc_env
+
+def Cc_envelope(
+    chromatic_aberration: float,  # in mm
+    image_shape: tuple[int, int] | tuple[int, int, int],
+    pixel_size: float,  # in angstroms
+    rfft: bool = True,
+    fftshift: bool = False,
+    device: torch.device = None,
+    voltage: float = 300,  # in kV
+    energy_spread: float = 0.7,  # in eV
+    deltaV_V: float = 0.06e-6,
+    deltaI_I: float = 0.01e-6,
+) -> torch.Tensor:
+    """
+    Create a Cc envelope for a Fourier transform.
+
+    Parameters
+    ----------
+    chromatic_aberration: float
+        The Cc value in mm
+    image_shape: tuple[int, ...]
+        Shape of the real space the dft is from input image.
+    pixel_size: float
+        The pixel size of the image in Å.
+    rfft: bool
+        Whether the input is from an rfft (True) or full fft (False).
+    fftshift: bool
+        Whether the input is fftshifted.
+    device: torch.device
+        Device to place tensors on.
+    voltage: float
+        The voltage of the microscope in kV.
+    energy_spread: float
+        The FWHM of the energy spread in eV.
+    deltaV_V: float
+        The relative voltage spread.
+    deltaI_I: float
+        The relative current spread
+
+    Returns
+    -------
+    torch.Tensor
+        Cc envelope
+    """
+    frequency_grid_px = (
+        fftfreq_grid(
+            image_shape=image_shape,
+            rfft=rfft,
+            fftshift=fftshift,
+            norm=True,
+            device=device,
+        )
+        / pixel_size
+    )
+    return _Cc_envelope(
+        frequency_grid_px,
+        chromatic_aberration,
+        voltage,
+        energy_spread,
+        deltaV_V,
+        deltaI_I,
+    )

--- a/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/envelopes.py
+++ b/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/envelopes.py
@@ -7,11 +7,12 @@ from torch_grid_utils.fftfreq_grid import fftfreq_grid
 
 def b_envelope(
     B: float,
-    image_shape: tuple[int, int] | tuple[int, int, int],
-    pixel_size: float,
+    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
+    pixel_size: float | None = None,
     rfft: bool = True,
     fftshift: bool = False,
     device: torch.device = None,
+    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create a B-factor envelope for a Fourier transform.
@@ -21,32 +22,47 @@ def b_envelope(
     B: float
         The B-factor value.
         Suggested value is 5 A^2 / e-/A^2
-    image_shape: tuple[int, ...]
+    image_shape: tuple[int, ...] | None
         Shape of the real space the dft is from input image.
-    pixel_size: float
-        The pixel size of the image.
+        Required when ``frequency_grid_px`` is not provided.
+    pixel_size: float | None
+        The pixel size of the image in Å.
+        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
+        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
+        Ignored when ``frequency_grid_px`` is provided.
     device: torch.device
         Device to place tensors on.
+        Ignored when ``frequency_grid_px`` is provided.
+    frequency_grid_px: torch.Tensor | None
+        Pre-computed frequency grid in Å⁻¹, equivalent to
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
+        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         B-factor envelope
     """
-    frequency_grid_px = (
-        fftfreq_grid(
-            image_shape=image_shape,
-            rfft=rfft,
-            fftshift=fftshift,
-            norm=True,
-            device=device,
+    if frequency_grid_px is None:
+        if image_shape is None or pixel_size is None:
+            raise ValueError(
+                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
+            )
+        frequency_grid_px = (
+            fftfreq_grid(
+                image_shape=image_shape,
+                rfft=rfft,
+                fftshift=fftshift,
+                norm=True,
+                device=device,
+            )
+            / pixel_size
         )
-        / pixel_size
-    )
 
     divisor = 4  # this is 4 for amplitude, 2 for intensity
     b_tensor = torch.exp(-(B * frequency_grid_px**2) / divisor)
@@ -55,14 +71,15 @@ def b_envelope(
 
 def dose_envelope(
     fluence: float,
-    image_shape: tuple[int, int] | tuple[int, int, int],
-    pixel_size: float,
+    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
+    pixel_size: float | None = None,
     rfft: bool = True,
     fftshift: bool = False,
     a: float = 0.245,
     b: float = -1.665,
     c: float = 2.81,
     device: torch.device = None,
+    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create Grant and Grigorieff 2015 dose envelope for a Fourier transform.
@@ -71,14 +88,18 @@ def dose_envelope(
     ----------
     fluence: float
         The fluence of the electron beam in e-/A^2.
-    image_shape: tuple[int, ...]
+    image_shape: tuple[int, ...] | None
         Shape of the real space the dft is from input image.
-    pixel_size: float
-        The pixel size of the image.
+        Required when ``frequency_grid_px`` is not provided.
+    pixel_size: float | None
+        The pixel size of the image in Å.
+        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
+        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
+        Ignored when ``frequency_grid_px`` is provided.
     a: float
         The a parameter of the dose envelope.
     b: float
@@ -87,22 +108,34 @@ def dose_envelope(
         The c parameter of the dose envelope.
     device: torch.device
         Device to place tensors on.
+        Ignored when ``frequency_grid_px`` is provided.
+    frequency_grid_px: torch.Tensor | None
+        Pre-computed frequency grid in Å⁻¹, equivalent to
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
+        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         Dose envelope
     """
-    frequency_grid_px = (
-        fftfreq_grid(
-            image_shape=image_shape,
-            rfft=rfft,
-            fftshift=fftshift,
-            norm=True,
-            device=device,
+    if frequency_grid_px is None:
+        if image_shape is None or pixel_size is None:
+            raise ValueError(
+                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
+            )
+        frequency_grid_px = (
+            fftfreq_grid(
+                image_shape=image_shape,
+                rfft=rfft,
+                fftshift=fftshift,
+                norm=True,
+                device=device,
+            )
+            / pixel_size
         )
-        / pixel_size
-    )
+
     if fluence < c:
         fluence_env = torch.ones_like(frequency_grid_px)
     else:
@@ -114,13 +147,14 @@ def dose_envelope(
 def Cs_envelope(
     spherical_aberration: float,  # in mm
     defocus: float,  # units in microns, positive for underfocus
-    image_shape: tuple[int, int] | tuple[int, int, int],
-    pixel_size: float,  # in angstroms
+    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
+    pixel_size: float | None = None,  # in angstroms
     rfft: bool = True,
     fftshift: bool = False,
     device: torch.device = None,
     voltage: float = 300,  # in kV
     alpha: float = 0.005,  # semiangle in mrad
+    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create a Cs envelope for a Fourier transform.
@@ -131,43 +165,58 @@ def Cs_envelope(
         The Cs value in mm
     defocus: float
         The defocus value in microns. Positive for underfocus.
-    image_shape: tuple[int, ...]
+    image_shape: tuple[int, ...] | None
         Shape of the real space the dft is from input image.
-    pixel_size: float
-        The pixel size of the image.
+        Required when ``frequency_grid_px`` is not provided.
+    pixel_size: float | None
+        The pixel size of the image in Å.
+        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
+        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
+        Ignored when ``frequency_grid_px`` is provided.
     device: torch.device
         Device to place tensors on.
+        Ignored when ``frequency_grid_px`` is provided.
     voltage: float
         The voltage of the microscope in kV.
     alpha: float
         The semiangle in mrad.
+    frequency_grid_px: torch.Tensor | None
+        Pre-computed frequency grid in Å⁻¹, equivalent to
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
+        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         Cs envelope
     """
+    if frequency_grid_px is None:
+        if image_shape is None or pixel_size is None:
+            raise ValueError(
+                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
+            )
+        frequency_grid_px = (
+            fftfreq_grid(
+                image_shape=image_shape,
+                rfft=rfft,
+                fftshift=fftshift,
+                norm=True,
+                device=device,
+            )
+            / pixel_size
+        )
+
     voltage *= 1e3  # kV -> V
     _lambda = (
         calculate_relativistic_electron_wavelength(voltage) * 1e10
     )  # wavelength meters -> angstroms
     Cs = spherical_aberration * 1e7  # mm -> angstroms
     defocus *= 1e4  # microns -> angstroms
-
-    frequency_grid_px = (
-        fftfreq_grid(
-            image_shape=image_shape,
-            rfft=rfft,
-            fftshift=fftshift,
-            norm=True,
-            device=device,
-        )
-        / pixel_size
-    )
 
     Cs_env = torch.exp(
         -(((torch.pi * (alpha / 1000)) / _lambda) ** 2)
@@ -183,15 +232,16 @@ def Cs_envelope(
 
 def Cc_envelope(
     chromatic_aberration: float,  # in mm
-    image_shape: tuple[int, int] | tuple[int, int, int],
-    pixel_size: float,  # in angstroms
+    image_shape: tuple[int, int] | tuple[int, int, int] | None = None,
+    pixel_size: float | None = None,  # in angstroms
     rfft: bool = True,
     fftshift: bool = False,
     device: torch.device = None,
     voltage: float = 300,  # in kV
     energy_spread: float = 0.7,  # in eV
-    deltaV_V: float = 0.06e-6,  #
-    deltaI_I: float = 0.01e-6,  #
+    deltaV_V: float = 0.06e-6,
+    deltaI_I: float = 0.01e-6,
+    frequency_grid_px: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Create a Cc envelope for a Fourier transform.
@@ -200,16 +250,21 @@ def Cc_envelope(
     ----------
     chromatic_aberration: float
         The Cc value in mm
-    image_shape: tuple[int, ...]
+    image_shape: tuple[int, ...] | None
         Shape of the real space the dft is from input image.
-    pixel_size: float
-        The pixel size of the image.
+        Required when ``frequency_grid_px`` is not provided.
+    pixel_size: float | None
+        The pixel size of the image in Å.
+        Required when ``frequency_grid_px`` is not provided.
     rfft: bool
         Whether the input is from an rfft (True) or full fft (False).
+        Ignored when ``frequency_grid_px`` is provided.
     fftshift: bool
         Whether the input is fftshifted.
+        Ignored when ``frequency_grid_px`` is provided.
     device: torch.device
         Device to place tensors on.
+        Ignored when ``frequency_grid_px`` is provided.
     voltage: float
         The voltage of the microscope in kV.
     energy_spread: float
@@ -218,28 +273,38 @@ def Cc_envelope(
         The relative voltage spread.
     deltaI_I: float
         The relative current spread
+    frequency_grid_px: torch.Tensor | None
+        Pre-computed frequency grid in Å⁻¹, equivalent to
+        ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
+        If provided, ``image_shape``, ``pixel_size``, ``rfft``, ``fftshift``,
+        and ``device`` are ignored and no new grid is allocated.
 
     Returns
     -------
     torch.Tensor
         Cc envelope
     """
+    if frequency_grid_px is None:
+        if image_shape is None or pixel_size is None:
+            raise ValueError(
+                "Provide either 'frequency_grid_px' (in Å⁻¹) or both 'image_shape' and 'pixel_size'."
+            )
+        frequency_grid_px = (
+            fftfreq_grid(
+                image_shape=image_shape,
+                rfft=rfft,
+                fftshift=fftshift,
+                norm=True,
+                device=device,
+            )
+            / pixel_size
+        )
+
     voltage *= 1e3  # kV -> V
     _lambda = (
         calculate_relativistic_electron_wavelength(voltage) * 1e10
     )  # wavelength meters -> angstroms
     Cc = chromatic_aberration * 1e7  # mm -> angstroms
-
-    frequency_grid_px = (
-        fftfreq_grid(
-            image_shape=image_shape,
-            rfft=rfft,
-            fftshift=fftshift,
-            norm=True,
-            device=device,
-        )
-        / pixel_size
-    )
 
     focus_spread = Cc * (
         ((energy_spread / voltage) ** 2 + deltaV_V**2 + (2 * deltaI_I) ** 2) ** 0.5

--- a/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/envelopes.py
+++ b/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/envelopes.py
@@ -16,7 +16,6 @@ def _b_envelope(frequency_grid_px: torch.Tensor, B: float) -> torch.Tensor:
         ``fftfreq_grid(image_shape, norm=True) / pixel_size``.
     B: float
         The B-factor value.
-        Suggested value is 5 A^2 / e-/A^2
 
     Returns
     -------
@@ -195,14 +194,12 @@ def _Cs_envelope(
     Cs = spherical_aberration * 1e7  # mm -> angstroms
     defocus *= 1e4  # microns -> angstroms
 
-    return torch.exp(
-        -(((torch.pi * (alpha / 1000)) / _lambda) ** 2)
-        * (
-            Cs * _lambda**3 * frequency_grid_px**3
-            + _lambda * (defocus) * frequency_grid_px
-        )
-        ** 2
-    )
+    aperture_term = (torch.pi * (alpha / 1000) / _lambda) ** 2
+    spherical_term = Cs * _lambda**3 * frequency_grid_px**3
+    defocus_term = _lambda * defocus * frequency_grid_px
+    phase_deviation = spherical_term + defocus_term
+
+    return torch.exp(-aperture_term * phase_deviation**2)
 
 
 def Cs_envelope(

--- a/packages/primitives/torch-fourier-filter/tests/test_envelopes.py
+++ b/packages/primitives/torch-fourier-filter/tests/test_envelopes.py
@@ -1,8 +1,13 @@
 import torch
+from torch_grid_utils.fftfreq_grid import fftfreq_grid
 
 from torch_fourier_filter.envelopes import (
     Cc_envelope,
     Cs_envelope,
+    _b_envelope,
+    _Cc_envelope,
+    _Cs_envelope,
+    _dose_envelope,
     b_envelope,
     dose_envelope,
 )
@@ -96,9 +101,9 @@ def test_Cc_envelope():
     )
 
     assert isinstance(Cc_env, torch.Tensor), "Output is not a torch.Tensor"
-    assert (
-        Cc_env.min() >= 0.0 and Cc_env.max() <= 1.0
-    ), "Values are out of expected range"
+    assert Cc_env.min() >= 0.0 and Cc_env.max() <= 1.0, (
+        "Values are out of expected range"
+    )
 
     # Test with real values
     image = torch.zeros((4, 4))
@@ -114,6 +119,145 @@ def test_Cc_envelope():
             [0.9427, 0.9427, 0.9427, 0.9427],
             [1.0493, 1.0493, 1.0493, 1.0493],
             [0.9427, 0.9427, 0.9427, 0.9427],
+        ]
+    )
+
+    assert torch.allclose(result, expected, atol=1e-3)
+
+
+def test_bfactor_2d_low_level():
+    # low-level math util applied to a manually-built frequency grid should
+    # reproduce the same result as the high-level wrapper in test_bfactor_2d,
+    # since callers with a cached grid call it directly.
+    image = torch.zeros((4, 4))
+    image[1:, :] = 1
+    dft = torch.fft.rfftn(image, dim=(-2, -1))
+    frequency_grid_px = fftfreq_grid(
+        image_shape=image.shape, rfft=True, fftshift=False, norm=True
+    )
+    b_env = _b_envelope(frequency_grid_px, B=10)
+    bfactored_dft = dft * b_env
+    result = torch.real(torch.fft.irfftn(bfactored_dft, dim=(-2, -1)))
+
+    expected = torch.tensor(
+        [
+            [
+                0.18851198,
+                0.18851198,
+                0.18851198,
+                0.18851198,
+            ],
+            [0.88381535, 0.88381535, 0.88381535, 0.88381535],
+            [1.0438573, 1.0438573, 1.0438573, 1.0438573],
+            [0.88381535, 0.88381535, 0.88381535, 0.88381535],
+        ]
+    )
+    assert torch.allclose(result, expected, atol=1e-3)
+
+
+def test_dose_envelope_low_level():
+    fluence = 20
+    image = torch.zeros((4, 4))
+    image[1:, :] = 1
+    dft = torch.fft.rfftn(image, dim=(-2, -1))
+    frequency_grid_px = fftfreq_grid(
+        image_shape=image.shape, rfft=True, fftshift=False, norm=True
+    )
+    dose_env = _dose_envelope(frequency_grid_px, fluence=fluence)
+    dft_env = dft * dose_env
+    result = torch.real(torch.fft.irfftn(dft_env, dim=(-2, -1)))
+
+    expected = torch.tensor(
+        [
+            [0.7495, 0.7495, 0.7495, 0.7495],
+            [0.7500, 0.7500, 0.7500, 0.7500],
+            [0.7505, 0.7505, 0.7505, 0.7505],
+            [0.7500, 0.7500, 0.7500, 0.7500],
+        ]
+    )
+    assert torch.allclose(result, expected, atol=1e-3)
+
+
+def test_Cc_envelope_low_level():
+    chromatic_aberration = 2.0  # in mm
+    image_shape = (4, 4)
+    voltage = 300  # in kV
+    energy_spread = 0.7  # in eV
+    deltaV_V = 0.06e-6
+    deltaI_I = 0.01e-6
+
+    frequency_grid_px = fftfreq_grid(
+        image_shape=image_shape, rfft=True, fftshift=False, norm=True
+    )
+    Cc_env = _Cc_envelope(
+        frequency_grid_px,
+        chromatic_aberration,
+        voltage,
+        energy_spread,
+        deltaV_V,
+        deltaI_I,
+    )
+
+    assert isinstance(Cc_env, torch.Tensor), "Output is not a torch.Tensor"
+    assert Cc_env.min() >= 0.0 and Cc_env.max() <= 1.0, (
+        "Values are out of expected range"
+    )
+
+    image = torch.zeros((4, 4))
+    image[1:, :] = 1
+    dft = torch.fft.rfftn(image, dim=(-2, -1))
+
+    Cc_dft = dft * Cc_env
+    result = torch.real(torch.fft.irfftn(Cc_dft, dim=(-2, -1)))
+
+    expected = torch.tensor(
+        [
+            [0.0654, 0.0654, 0.0654, 0.0654],
+            [0.9427, 0.9427, 0.9427, 0.9427],
+            [1.0493, 1.0493, 1.0493, 1.0493],
+            [0.9427, 0.9427, 0.9427, 0.9427],
+        ]
+    )
+
+    assert torch.allclose(result, expected, atol=1e-3)
+
+
+def test_Cs_envelope_low_level():
+    spherical_aberration = 2.0  # in mm
+    defocus = 1.0  # in microns,
+    image_shape = (4, 4)
+    voltage = 300  # in kV
+    alpha = 0.005  # in mrad
+
+    frequency_grid_px = fftfreq_grid(
+        image_shape=image_shape, rfft=True, fftshift=False, norm=True
+    )
+    Cs_env = _Cs_envelope(
+        frequency_grid_px,
+        spherical_aberration,
+        defocus,
+        voltage,
+        alpha,
+    )
+
+    assert isinstance(Cs_env, torch.Tensor), "Output is not a torch.Tensor"
+    assert Cs_env.min() >= 0.0 and Cs_env.max() <= 1.0, (
+        "Values are out of expected range"
+    )
+
+    image = torch.zeros((4, 4))
+    image[1:, :] = 1
+    dft = torch.fft.rfftn(image, dim=(-2, -1))
+
+    Cs_dft = dft * Cs_env
+    result = torch.real(torch.fft.irfftn(Cs_dft, dim=(-2, -1)))
+
+    expected = torch.tensor(
+        [
+            [0.0030, 0.0030, 0.0030, 0.0030],
+            [0.9978, 0.9978, 0.9978, 0.9978],
+            [1.0013, 1.0013, 1.0013, 1.0013],
+            [0.9978, 0.9978, 0.9978, 0.9978],
         ]
     )
 
@@ -144,9 +288,9 @@ def test_Cs_envelope():
     )
 
     assert isinstance(Cs_env, torch.Tensor), "Output is not a torch.Tensor"
-    assert (
-        Cs_env.min() >= 0.0 and Cs_env.max() <= 1.0
-    ), "Values are out of expected range"
+    assert Cs_env.min() >= 0.0 and Cs_env.max() <= 1.0, (
+        "Values are out of expected range"
+    )
 
     # Test with real values
     image = torch.zeros((4, 4))


### PR DESCRIPTION
Allow callers to pass a pre-computed frequency grid in Å⁻¹ to b_envelope, dose_envelope, Cs_envelope, and Cc_envelope via the new frequency_grid_px keyword argument.

Motivation: these functions may be often called repeatedly from a stateful class that already holds a cached frequency grid (e.g. registered as a buffer on a nn.Module). Previously, each call would unconditionally allocate a new grid tensor even though the shape and pixel size never change. Passing frequency_grid_px skips that allocation entirely.

Backwards compatibility: fully preserved. image_shape and pixel_size work exactly as before when frequency_grid_px is not provided. A ValueError is raised only if neither is supplied.