### PR TITLE
feat(torch-refine-tilt-axis-angle): rewrite as a grid search on the Fourier sum of the stack

### DIFF
--- a/packages/algorithms/torch-refine-tilt-axis-angle/README.md
+++ b/packages/algorithms/torch-refine-tilt-axis-angle/README.md
@@ -10,7 +10,17 @@ Tilt-axis angle optimization for tilt series using common lines.
 
 ## Overview
 
-torch-refine-tilt-axis-angle provides an implementation for finding the in plane rotation for a tilt-series that aligns the tilt axis with the y-axis. This is done by extracting lines from the 2D Fourier transform of the tilt-series images and minimizing the mean squared error between them, i.e. the common lines. It makes use of the pytorch LBFGS optimizer to find the minimum.
+torch-refine-tilt-axis-angle finds the tilt-axis angle of a translationally
+aligned tilt series from its common line: the line through the origin of
+Fourier space that all tilt images share, oriented perpendicular to the tilt
+axis. Each image's Fourier transform is coherently summed across the stack,
+and a two-stage angular grid search (coarse, then a finer search around the
+coarse optimum) locates the orientation of highest power in the summed power
+spectrum. The whole search is evaluated as batched tensor operations, so
+every candidate angle is scored in parallel rather than in a Python loop.
+
+Rectangular images are handled natively, without cropping to square, so no
+image data is discarded.
 
 ## Installation
 
@@ -29,23 +39,16 @@ from torch_refine_tilt_axis_angle import refine_tilt_axis_angle
 # Example: tilt_series with shape (61, 512, 512) - 61 tilt images of 512x512 pixels
 tilt_series = torch.randn(61, 512, 512)
 
-# Specify an initial guess for the tilt axis angle (the default is 0.0)
-# This can be the value from an MDOC file.
+# Specify an initial guess for the tilt axis angle (the default is 90.0,
+# which searches the full [0, 180] range). This can be the value from an
+# MDOC file.
 initial_tilt_axis_angle = 50.0
 
 # Run tilt axis angle refinement.
 new_tilt_axis_angle = refine_tilt_axis_angle(
     tilt_series=tilt_series,
     tilt_axis_angle=initial_tilt_axis_angle,
-    # grid_points=1,  # optionally increase the spline grid points (default 1)
-    # return_single_angle=False,  # optionally write out an angle for each image 
 )
-```
-
-Use [uv](https://docs.astral.sh/uv/) to run an example with simulated data and visualize the results.
-
-```shell
-uv run examples/simulate_tilt_axis_refinement.py
 ```
 
 ## License

--- a/packages/algorithms/torch-refine-tilt-axis-angle/pyproject.toml
+++ b/packages/algorithms/torch-refine-tilt-axis-angle/pyproject.toml
@@ -45,11 +45,6 @@ classifiers = [
 # add your package dependencies here
 dependencies = [
     "torch",
-    "einops",
-    "torch-fourier-slice",
-    "torch-cubic-spline-grids",
-    "torch-affine-utils",
-    "torch-grid-utils",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/packages/algorithms/torch-refine-tilt-axis-angle/src/torch_refine_tilt_axis_angle/refine_tilt_axis_angle.py
+++ b/packages/algorithms/torch-refine-tilt-axis-angle/src/torch_refine_tilt_axis_angle/refine_tilt_axis_angle.py
@@ -1,112 +1,153 @@
 """Refine an initial tilt axis angle."""
 
-import einops
 import torch
-from scipy.optimize import minimize_scalar  # type: ignore[import-untyped]
-from torch_affine_utils.transforms_2d import R
-
-# teamtomo torch functionality
-from torch_fourier_slice import project_2d_to_1d  # type: ignore[import-untyped]
-from torch_grid_utils import circle  # type: ignore[import-untyped]
 
 
 def refine_tilt_axis_angle(
     tilt_series: torch.Tensor,
-    tilt_axis_angle: float = 0.0,
-    search_range: float = 10.0,
-    max_iter: int = 20,
+    tilt_axis_angle: float = 90.0,
+    coarse_angle_step: float = 0.5,
+    min_fraction_of_nyquist: float = 0.08,
+    max_fraction_of_nyquist: float = 0.95,
+    refine: bool = True,
+    refine_range: float = 3.0,
+    refine_angle_step: float = 0.1,
 ) -> float:
-    """Refine the tilt axis angle for electron tomography data.
+    """Find the tilt-axis angle of a tilt series from its common line.
 
-    Uses common line projections and scipy's Brent's method (bounded) to find
-    the optimal tilt axis angle that minimizes differences between projections
-    across the tilt series.
+    All images of a translationally-aligned tilt series share Fourier
+    information along a common line through the origin, perpendicular to
+    the tilt axis. Coherently summing the images' Fourier transforms makes
+    this line stand out as a ridge of high power, so the tilt-axis angle
+    can be recovered by finding the ridge's orientation via a two-stage
+    (coarse, then fine) angular grid search, evaluated as batched tensor
+    operations across all candidate angles at once.
+
+    Rectangular images are handled natively, via a normalized frequency
+    shared by both axes and converted to per-axis pixel indices only at
+    lookup time.
 
     Parameters
     ----------
     tilt_series : torch.Tensor
-        Tensor containing the tilt series images with shape [n_tilts, height, width].
-    tilt_axis_angle : float, default=0.0
-        Initial guess for the tilt axis angle in degrees.
-    search_range : float, default=10.0
-        Search range around the initial angle in degrees (±search_range).
-    max_iter : int, default=10
-        Maximum iterations for Brent's method optimizer.
+        Tensor containing the tilt series images with shape
+        `(n_tilts, h, w)`. Should already be translationally aligned and,
+        ideally, ramp- and bandpass-filtered. A pixel size of 10A is
+        recommended.
+    tilt_axis_angle : float, default=90.0
+        Initial guess for the tilt axis angle in degrees. The search range
+        is `[tilt_axis_angle - 90, tilt_axis_angle + 90]`. The default of
+        90.0 searches the full `[0, 180]` range.
+    coarse_angle_step : float, default=0.5
+        Step size for the coarse grid search (degrees).
+    min_fraction_of_nyquist : float, default=0.08
+        Minimum frequency radius searched, as a fraction of Nyquist.
+    max_fraction_of_nyquist : float, default=0.95
+        Maximum frequency radius searched, as a fraction of Nyquist.
+    refine : bool, default=True
+        Whether to run a finer search around the coarse optimum.
+    refine_range : float, default=3.0
+        Range around the coarse optimum searched during refinement
+        (degrees).
+    refine_angle_step : float, default=0.1
+        Step size for the fine grid search (degrees).
 
     Returns
     -------
     float
-        The optimized tilt axis angle in degrees.
-
-    Notes
-    -----
-    The function works by:
-    1. Projecting images perpendicular to the tilt axis to extract common lines
-    2. Comparing these projections across different tilts
-    3. Minimizing differences between projections using Brent's method
-
-    Common line projections are normalized and weighted according to a
-    projected spherical mask to emphasize regions of interest.
+        The tilt axis angle in degrees, in
+        `[tilt_axis_angle - 90, tilt_axis_angle + 90]`.
     """
-    n_tilts, h, w = tilt_series.shape
+    _, h, w = tilt_series.shape
     device = tilt_series.device
-    size = min(h, w)
 
-    # use a spherical real-space alignment mask, quick way to get around #4
-    alignment_mask = circle(
-        radius=size // 3,
-        smoothing_radius=size // 6,
-        image_shape=(h, w),
+    # Hann taper: suppresses the FFT edge artifact from non-periodic boundaries.
+    mask = torch.outer(
+        torch.hann_window(h, periodic=False, device=device),
+        torch.hann_window(w, periodic=False, device=device),
+    )
+
+    # coherent complex rfft sum across the stack
+    windowed = (tilt_series - tilt_series.mean(dim=(-2, -1), keepdim=True)) * mask
+    power_sum = torch.fft.rfft2(windowed).sum(dim=0).abs() ** 2
+
+    # Shared normalized-frequency sample points, converted to per-axis pixel
+    # indices only at lookup time. Sampled at the longer dimension's density.
+    n_samples = max(h, w) // 2
+    rhos = torch.linspace(
+        min_fraction_of_nyquist * 0.5,
+        max_fraction_of_nyquist * 0.5,
+        n_samples,
         device=device,
     )
-    masked_tilt_series = tilt_series * alignment_mask
 
-    # generate a weighting for the common line ROI by projecting the mask
-    mask_weights = project_2d_to_1d(
-        alignment_mask,
-        torch.eye(2, device=device),  # angle does not matter for circle
+    # the tilt axis is perpendicular to the direction of the common line
+    common_line_angle = tilt_axis_angle - 90.0
+
+    # coarse grid search within +/-90 deg of the initial guess
+    coarse_angles = torch.arange(
+        common_line_angle - 90.0,
+        common_line_angle + 90.0,
+        coarse_angle_step,
+        device=device,
     )
-    mask_weights = mask_weights / mask_weights.max()  # normalise to 0 and 1
+    image_shape = (h, w)
+    power = _common_line_power(coarse_angles, rhos, power_sum, image_shape)
+    best_angle = float(coarse_angles[torch.argmax(power)])
 
-    def objective(angle: float) -> float:
-        """Objective function: compute loss for given tilt axis angle."""
-        # The common line is the projection perpendicular to the
-        # tilt-axis, hence add 90 degrees to project along the x-axis
-        angle_tensor = torch.tensor(
-            [angle + 90.0] * n_tilts,
-            dtype=torch.float32,
+    if refine:
+        # fine grid search around the coarse optimum
+        fine_angles = torch.arange(
+            best_angle - refine_range,
+            best_angle + refine_range + refine_angle_step,
+            refine_angle_step,
             device=device,
         )
-        M = R(angle_tensor, yx=False)
-        M = M[:, :2, :2]  # we only need the rotation matrix
+        power = _common_line_power(fine_angles, rhos, power_sum, image_shape)
+        best_angle = float(fine_angles[torch.argmax(power)])
 
-        projections = torch.cat(
-            [  # indexing with [[i]] does not drop the dimension
-                project_2d_to_1d(masked_tilt_series[i], M[[i]]) for i in range(n_tilts)
-            ]
-        )
-        projections = projections - einops.reduce(
-            projections, "tilt w -> tilt 1", reduction="mean"
-        )
-        projections = projections / torch.std(projections, dim=(-1), keepdim=True)
-        projections = projections * mask_weights  # weight the common lines
+    return best_angle + 90.0
 
-        squared_differences = (
-            projections - einops.rearrange(projections, "b d -> b 1 d")
-        ) ** 2
-        loss = einops.reduce(squared_differences, "b1 b2 d -> 1", reduction="sum")
-        return float(loss.item())
 
-    # Define search bounds
-    angle_min = tilt_axis_angle - search_range
-    angle_max = tilt_axis_angle + search_range
+def _common_line_power(
+    angles_deg: torch.Tensor,
+    rhos: torch.Tensor,
+    power_sum: torch.Tensor,
+    image_shape: tuple[int, int],
+) -> torch.Tensor:
+    """Total power along the line through the origin at each angle.
 
-    # Run Brent's method optimization
-    result = minimize_scalar(
-        objective,
-        bounds=(angle_min, angle_max),
-        method="bounded",
-        options={"maxiter": max_iter},
-    )
+    Looks up only the stored (non-negative-frequency) half of the rfft
+    spectrum: for directions with `cos(theta) < 0`, the conjugate-symmetric
+    point `F(-fy, -fx) = conj(F(fy, fx))` is looked up instead, which has
+    the same magnitude.
 
-    return float(result.x)
+    Parameters
+    ----------
+    angles_deg : torch.Tensor
+        `(angle, )` candidate line angles in degrees.
+    rhos : torch.Tensor
+        `(rho, )` normalized frequency radii shared by both axes.
+    power_sum : torch.Tensor
+        `(h, w // 2 + 1)` power spectrum, non-fftshifted rfft2 layout.
+    image_shape : tuple[int, int]
+        `(h, w)` shape of the original (pre-rfft) images.
+
+    Returns
+    -------
+    power : torch.Tensor
+        `(angle, )` total power along the line at each candidate angle.
+    """
+    h, w = image_shape
+    rad = torch.deg2rad(angles_deg)
+    cos, sin = torch.cos(rad), torch.sin(rad)
+    fy = sin[:, None] * rhos[None, :]  # (angle, rho)
+    fx = cos[:, None] * rhos[None, :]  # (angle, rho)
+    flip = (cos < 0)[:, None]
+    fy, fx = torch.where(flip, -fy, fy), torch.where(flip, -fx, fx)
+
+    rows = torch.round(fy * h).long() % h
+    cols = torch.round(fx * w).long()
+    valid = (cols >= 0) & (cols < power_sum.shape[-1])
+    values = power_sum[rows, cols.clamp(0, power_sum.shape[-1] - 1)]
+    return (values * valid).sum(dim=-1)

--- a/packages/algorithms/torch-refine-tilt-axis-angle/tests/test_torch_refine_tilt_axis_angle.py
+++ b/packages/algorithms/torch-refine-tilt-axis-angle/tests/test_torch_refine_tilt_axis_angle.py
@@ -1,116 +1,204 @@
-from unittest.mock import MagicMock, patch
+import math
 
 import pytest
 import torch
 
 from torch_refine_tilt_axis_angle import refine_tilt_axis_angle
+from torch_refine_tilt_axis_angle.refine_tilt_axis_angle import _common_line_power
 
 
-@pytest.fixture
-def sample_data():
-    """Generate sample data for testing."""
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+def _tilt_series_with_common_line(
+    image_shape: tuple[int, int],
+    tilt_axis_angle: float,
+    n_tilts: int = 30,
+    n_harmonics: int = 20,
+    noise_std: float = 1.0,
+    seed: int = 0,
+) -> torch.Tensor:
+    """Build a synthetic stack that shares Fourier content along one direction.
 
-    # Create a small tilt series (5 images of 20x20 pixels)
-    tilt_series = torch.rand(5, 20, 20, device=device)
+    Each image is `common(u) + independent_noise`, where `u` is the
+    coordinate along `tilt_axis_angle` and `common` is identical across the
+    stack. `common` is a broadband sum of random sinusoids so it populates a
+    continuous ridge in Fourier space, rather than a couple of isolated
+    frequency bins. Real tilt series behave the same way: every image's
+    Fourier transform agrees along the line perpendicular to the tilt axis
+    (the common line), which is exactly the structure
+    `refine_tilt_axis_angle` is designed to detect.
+    """
+    h, w = image_shape
+    generator = torch.Generator().manual_seed(seed)
+    y = torch.linspace(-h / 2, h / 2, h)
+    x = torch.linspace(-w / 2, w / 2, w)
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+    rad = math.radians(tilt_axis_angle)
+    u = yy * math.cos(rad) - xx * math.sin(rad)
 
-    return {"tilt_series": tilt_series, "device": device}
+    periods = torch.linspace(4, 40, n_harmonics)
+    phases = torch.rand(n_harmonics, generator=generator) * 2 * torch.pi
+    amplitudes = 0.5 + torch.rand(n_harmonics, generator=generator)
+    common = sum(
+        amplitudes[i] * torch.sin(2 * torch.pi * u / periods[i] + phases[i])
+        for i in range(n_harmonics)
+    )
+
+    noise = noise_std * torch.randn((n_tilts, h, w), generator=generator)
+    return common + noise
 
 
-def test_refine_tilt_axis_angle_default_parameters(sample_data):
-    """Test refine_tilt_axis_angle with default parameters."""
-    mock_result = MagicMock()
-    mock_result.x = 0.0
-
-    with patch(
-        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
-        return_value=mock_result,
-    ):
-        # Setup
-        tilt_series = sample_data["tilt_series"]
-
-        # Call the function with default parameters
-        result = refine_tilt_axis_angle(tilt_series=tilt_series)
-
-        # Assertions
-        assert isinstance(result, float)
+def _angular_distance(a: float, b: float) -> float:
+    """Smallest difference between two angles, modulo the 180 deg line symmetry."""
+    return abs((a - b + 90) % 180 - 90)
 
 
-def test_refine_tilt_axis_angle_with_custom_parameters(sample_data):
-    """Test refine_tilt_axis_angle with custom parameters."""
-    # Create a mock result object
-    mock_result = MagicMock()
-    mock_result.x = 42.5
+@pytest.mark.parametrize("image_shape", [(96, 96), (80, 128), (128, 80)])
+@pytest.mark.parametrize("true_angle", [10.0, 55.0, 100.0, 150.0])
+def test_refine_tilt_axis_angle_recovers_known_angle(image_shape, true_angle):
+    """The common line direction should be recovered to sub-degree precision."""
+    tilt_series = _tilt_series_with_common_line(image_shape, tilt_axis_angle=true_angle)
 
-    with patch(
-        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
-        return_value=mock_result,
-    ):
-        # Setup
-        tilt_series = sample_data["tilt_series"]
-        initial_angle = 45.0
+    result = refine_tilt_axis_angle(tilt_series)
 
-        # Call the function
-        result = refine_tilt_axis_angle(
-            tilt_series=tilt_series,
-            tilt_axis_angle=initial_angle,
-            search_range=15.0,
-            max_iter=20,
+    assert isinstance(result, float)
+    assert _angular_distance(result, true_angle) < 1.0
+
+
+def test_refine_tilt_axis_angle_respects_search_window():
+    """The result must lie within +/-90 deg of the initial guess, unwrapped."""
+    true_angle = 100.0
+    tilt_series = _tilt_series_with_common_line((96, 96), tilt_axis_angle=true_angle)
+
+    initial_guess = 30.0
+    result = refine_tilt_axis_angle(tilt_series, tilt_axis_angle=initial_guess)
+
+    assert initial_guess - 90 <= result <= initial_guess + 90
+    assert _angular_distance(result, true_angle) < 1.0
+
+
+def test_refine_tilt_axis_angle_without_refinement_step():
+    """Skipping refinement should still recover the angle to coarse precision."""
+    true_angle = 42.0
+    tilt_series = _tilt_series_with_common_line((96, 96), tilt_axis_angle=true_angle)
+
+    coarse_angle_step = 1.0
+    result = refine_tilt_axis_angle(
+        tilt_series, coarse_angle_step=coarse_angle_step, refine=False
+    )
+
+    assert isinstance(result, float)
+    assert _angular_distance(result, true_angle) <= coarse_angle_step
+
+
+def test_refine_tilt_axis_angle_respects_radius_band():
+    """min/max_fraction_of_nyquist should select which frequencies are used.
+
+    Builds a stack containing two common lines at different angles, one
+    carried entirely by long-period (low frequency) content and the other
+    entirely by short-period (high frequency) content. Restricting the
+    search to each frequency band in turn should recover the angle that
+    lives in that band, proving the radius bounds actually take effect
+    rather than just being accepted and ignored.
+    """
+    image_shape = (96, 96)
+    h, w = image_shape
+    angle_low, angle_high = 20.0, 110.0
+    generator = torch.Generator().manual_seed(1)
+
+    y = torch.linspace(-h / 2, h / 2, h)
+    x = torch.linspace(-w / 2, w / 2, w)
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+
+    def _common(angle_deg: float, periods: list[float]) -> torch.Tensor:
+        rad = math.radians(angle_deg)
+        u = yy * math.cos(rad) - xx * math.sin(rad)
+        phases = torch.rand(len(periods), generator=generator) * 2 * torch.pi
+        return sum(
+            torch.sin(2 * torch.pi * u / period + phase)
+            for period, phase in zip(periods, phases, strict=True)
         )
 
-        # Assertions
-        assert isinstance(result, float)
-        assert result == 42.5
+    low_freq_signal = _common(angle_low, periods=list(torch.linspace(24, 40, 10)))
+    high_freq_signal = _common(angle_high, periods=list(torch.linspace(4, 6, 10)))
+    noise = 0.5 * torch.randn((30, h, w), generator=generator)
+    tilt_series = low_freq_signal + high_freq_signal + noise
+
+    low_band_result = refine_tilt_axis_angle(
+        tilt_series, min_fraction_of_nyquist=0.02, max_fraction_of_nyquist=0.12
+    )
+    high_band_result = refine_tilt_axis_angle(
+        tilt_series, min_fraction_of_nyquist=0.3, max_fraction_of_nyquist=0.6
+    )
+
+    assert _angular_distance(low_band_result, angle_low) < 1.0
+    assert _angular_distance(high_band_result, angle_high) < 1.0
 
 
-def test_refine_tilt_axis_angle_bounds(sample_data):
-    """Test that minimize_scalar is called with correct bounds."""
-    mock_result = MagicMock()
-    mock_result.x = 5.0
+def test_refine_tilt_axis_angle_refine_step_improves_precision():
+    """A finer refine_angle_step/refine_range should beat the coarse grid alone."""
+    true_angle = 63.0
+    tilt_series = _tilt_series_with_common_line((96, 96), tilt_axis_angle=true_angle)
 
-    with patch(
-        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
-        return_value=mock_result,
-    ) as mock_minimize:
-        # Setup
-        tilt_series = sample_data["tilt_series"]
-        initial_angle = 30.0
-        search_range = 10.0
+    coarse_only = refine_tilt_axis_angle(
+        tilt_series, coarse_angle_step=2.0, refine=False
+    )
+    refined = refine_tilt_axis_angle(
+        tilt_series,
+        coarse_angle_step=2.0,
+        refine=True,
+        refine_range=2.0,
+        refine_angle_step=0.05,
+    )
 
-        # Call the function
-        refine_tilt_axis_angle(
-            tilt_series=tilt_series,
-            tilt_axis_angle=initial_angle,
-            search_range=search_range,
-        )
-
-        # Assert minimize_scalar was called with correct bounds
-        mock_minimize.assert_called_once()
-        call_kwargs = mock_minimize.call_args[1]
-        assert call_kwargs["bounds"] == (20.0, 40.0)  # initial ± search_range
-        assert call_kwargs["method"] == "bounded"
+    coarse_error = _angular_distance(coarse_only, true_angle)
+    refined_error = _angular_distance(refined, true_angle)
+    assert refined_error < coarse_error
+    assert refined_error < 0.5
 
 
-def test_refine_tilt_axis_angle_optimization_max_iter(sample_data):
-    """Test that max_iter parameter is passed to minimize_scalar."""
-    mock_result = MagicMock()
-    mock_result.x = 0.0
+def _make_indexable_power_sum(image_shape: tuple[int, int]) -> torch.Tensor:
+    """A power spectrum with a distinct value at every bin, for exact assertions."""
+    h, w = image_shape
+    return torch.arange(h * (w // 2 + 1), dtype=torch.float32).reshape(h, w // 2 + 1)
 
-    with patch(
-        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
-        return_value=mock_result,
-    ) as mock_minimize:
-        # Setup
-        tilt_series = sample_data["tilt_series"]
-        max_iter = 15
 
-        # Call the function
-        refine_tilt_axis_angle(
-            tilt_series=tilt_series,
-            max_iter=max_iter,
-        )
+def test_common_line_power_indexes_expected_bins():
+    """Row wraparound, column lookup, and conjugate-symmetry flip, checked exactly.
 
-        # Assert minimize_scalar was called with correct max_iter
-        mock_minimize.assert_called_once()
-        call_kwargs = mock_minimize.call_args[1]
-        assert call_kwargs["options"]["maxiter"] == max_iter
+    Uses a power spectrum where every bin holds a distinct value, so the bins
+    picked out by `_common_line_power` can be checked against hand-computed
+    expected indices rather than merely trusting the code ran.
+    """
+    image_shape = (8, 8)
+    power_sum = _make_indexable_power_sum(image_shape)
+    rhos = torch.tensor([0.25])
+
+    # theta=0: fy=0, fx=0.25 -> row 0, col round(0.25*8)=2.
+    # theta=80: fy=sin(80)*0.25=0.246, fx=cos(80)*0.25=0.043
+    #   -> row round(0.246*8)=2, col round(0.043*8)=0.
+    # theta=260 (=80+180): same line as theta=80, but cos<0 so the conjugate
+    # point is looked up instead; should land on the exact same bin as
+    # theta=80 despite theta=260's own (fy, fx) being different.
+    angles = torch.tensor([0.0, 80.0, 260.0])
+    power = _common_line_power(angles, rhos, power_sum, image_shape)
+
+    expected = torch.tensor([power_sum[0, 2], power_sum[2, 0], power_sum[2, 0]])
+    assert torch.equal(power, expected)
+
+
+def test_common_line_power_masks_out_of_range_frequencies():
+    """Frequencies that round outside the stored rfft columns contribute zero."""
+    image_shape = (8, 8)
+    power_sum = _make_indexable_power_sum(image_shape)
+
+    # rho=0.6 is above Nyquist (0.5): at theta=0, col = round(0.6*8) = 5,
+    # which is out of range for a w=8 rfft (valid columns are 0..4).
+    out_of_range_power = _common_line_power(
+        torch.tensor([0.0]), torch.tensor([0.6]), power_sum, image_shape
+    )
+    assert out_of_range_power.item() == 0.0
+
+    # a valid rho at the same angle should pick up the real bin value instead.
+    in_range_power = _common_line_power(
+        torch.tensor([0.0]), torch.tensor([0.4]), power_sum, image_shape
+    )
+    assert in_range_power.item() == power_sum[0, 3]


### PR DESCRIPTION
Closes #94

Before this ran a gradient descent optimization algorithm that would for each angle extract common lines from the 2D images. This was prone to end up in a local minimum, because its not a smooth landscape.

With this update: it sums the power spectra of the aligned tilt stack. It then search magnitudes around possible angles of the common line. Its all vectorized so its much faster. By default, it does a coarse grid search first in the range of [initial_axis - 90, initial_axis + 90] with a .5 degrees increment. It then refines the detected in the angle in the range of [current_best - 3, current_best + 3] with a 0.1 degrees increment.

I am also thinking if it would not be easier if we would just have one teamtomo.tilt_series_alignment module from which find_tilt_axis_angle and tiltxcorr could be imported. As well as some bandpass + edge taper + ramp subtraction, instead of having to do that both in tiltxcorr and in find_tilt_axis_angle. But I will make an issue about that after this to discuss further.

