### PR TITLE
Fix torch-subpixel-crop decenter shift for odd sidelengths

### DIFF
--- a/packages/primitives/torch-subpixel-crop/src/torch_subpixel_crop/subpixel_crop_2d.py
+++ b/packages/primitives/torch-subpixel-crop/src/torch_subpixel_crop/subpixel_crop_2d.py
@@ -36,7 +36,7 @@ def subpixel_crop_2d(
          rffts have their origin at (0, 0)
     decenter : bool, default False
         In case the patches are returned as rft, optionally also apply an
-         additional shift of sidelength / 2 so that the real space image has its origin
+         additional shift of sidelength // 2 so that the real space image has its origin
          at 0. NOTE: this does not change the origin in Fourier space, the rffts
          still have their origin at (0, 0)
 
@@ -146,7 +146,7 @@ def _extract_patches_batched(
         patches_dft = torch.fft.rfftn(patches, dim=(-2, -1))
 
         if decenter:
-            shifts = shifts + pw / 2
+            shifts = shifts + pw // 2
 
         # apply the subpixel shift
         patches_dft = fourier_shift_dft_2d(

--- a/packages/primitives/torch-subpixel-crop/src/torch_subpixel_crop/subpixel_crop_3d.py
+++ b/packages/primitives/torch-subpixel-crop/src/torch_subpixel_crop/subpixel_crop_3d.py
@@ -42,7 +42,7 @@ def subpixel_crop_3d(
          rffts have their origin at (0, 0)
     decenter : bool, default False
         In case the patches are returned as rft, optionally also apply an
-         additional shift of sidelength / 2 so that the real space image has its origin
+         additional shift of sidelength // 2 so that the real space image has its origin
          at 0. NOTE: this does not change the origin in Fourier space, the rffts
          still have their origin at (0, 0)
 
@@ -89,7 +89,7 @@ def subpixel_crop_3d(
         patches = torch.fft.rfftn(patches, dim=(-3, -2, -1))
 
         if decenter:
-            shifts = shifts + pw / 2
+            shifts = shifts + pw // 2
 
         # apply the subpixel shift
         patches = fourier_shift_dft_3d(

--- a/packages/primitives/torch-subpixel-crop/tests/test_subpixel_crop_2d.py
+++ b/packages/primitives/torch-subpixel-crop/tests/test_subpixel_crop_2d.py
@@ -68,6 +68,34 @@ def test_subpixel_crop_single_2d_return_rfft_decenter():
     assert torch.allclose(cropped_image_decenter, cropped_image_real)
 
 
+def test_subpixel_crop_single_2d_return_rfft_decenter_odd_sidelength():
+    image = torch.zeros((10, 10))
+    image[4:6, 4:6] = 1
+
+    cropped_image_real = subpixel_crop_2d(
+        image=image,
+        positions=torch.tensor([5.5, 5.5]).float(),
+        sidelength=5
+    )
+
+    cropped_image_decenter = subpixel_crop_2d(
+        image=image,
+        positions=torch.tensor([5.5, 5.5]).float(),
+        sidelength=5,
+        return_rfft=True,
+        decenter=True,
+    )
+    cropped_image_decenter = torch.fft.irfftn(
+        cropped_image_decenter, s=(5, 5)
+    )
+    # for odd sidelengths, fftshift and ifftshift differ by one sample;
+    # decenter shifts by +(sidelength // 2), so ifftshift is the correct undo
+    cropped_image_decenter = (
+        torch.fft.ifftshift(cropped_image_decenter, dim=(-2, -1))
+    )
+    assert torch.allclose(cropped_image_decenter, cropped_image_real, atol=1e-5)
+
+
 def test_subpixel_crop_2d_with_fourier_shift():
     image = torch.zeros((10, 10))
     image[4:6, 4:6] = 1

--- a/packages/primitives/torch-subpixel-crop/tests/test_subpixel_crop_3d.py
+++ b/packages/primitives/torch-subpixel-crop/tests/test_subpixel_crop_3d.py
@@ -66,6 +66,34 @@ def test_subpixel_crop_single_3d_return_rfft_decenter():
     assert torch.allclose(cropped_image_decenter, cropped_image_real)
 
 
+def test_subpixel_crop_single_3d_return_rfft_decenter_odd_sidelength():
+    image = torch.zeros((10, 10, 10))
+    image[4:6, 4:6, 4:6] = 1
+
+    cropped_image_real = subpixel_crop_3d(
+        image=image,
+        positions=torch.tensor([5.5, 5.5, 5.5]).float(),
+        sidelength=5
+    )
+
+    cropped_image_decenter = subpixel_crop_3d(
+        image=image,
+        positions=torch.tensor([5.5, 5.5, 5.5]).float(),
+        sidelength=5,
+        return_rfft=True,
+        decenter=True,
+    )
+    cropped_image_decenter = (
+        torch.fft.irfftn(cropped_image_decenter, s=(5, 5, 5))
+    )
+    # for odd sidelengths, fftshift and ifftshift differ by one sample;
+    # decenter shifts by +(sidelength // 2), so ifftshift is the correct undo
+    cropped_image_decenter = (
+        torch.fft.ifftshift(cropped_image_decenter, dim=(-3, -2, -1))
+    )
+    assert torch.allclose(cropped_image_decenter, cropped_image_real, atol=1e-5)
+
+
 def test_subpixel_crop_multi_3d():
     image = torch.zeros((10, 10, 10))
     image[4:6, 4:6, 4:6] = 1


### PR DESCRIPTION
Noticed a bug in torch-subpixel-crop when rfft's are returned for odd dimensions.

Context about why this is needed:
* when you crop subtilts from tilt series you often do this to make subvolume reconstructions
* when making subvolume reconstructions using Fourier inversion, you need to run an ifftshift on the projection images before taking the rfft
* subpixel crop applies a subpixel shift in Fourier space, so when we anyway rfft the images for the subpixel shift we can already apply the shift we need for the 'ifftshift in real space'

The previous code was doing floating point division which can never be correct for fftshifts. For even dimensions this doesn't matter but for odd dimension this is an issue. 