### PR TITLE
fix torch-fourier-slice for odd sized dimensions

### DIFF
--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/backproject.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/backproject.py
@@ -72,7 +72,7 @@ def backproject_2d_to_3d(
     volume_shape = (w, w, w)
 
     # calculate DFTs of images
-    images = torch.fft.fftshift(images, dim=(-2, -1))  # volume center to array origin
+    images = torch.fft.ifftshift(images, dim=(-2, -1))  # volume center to array origin
     images = torch.fft.rfftn(images, dim=(-2, -1))
     images = torch.fft.fftshift(images, dim=(-2,))  # actual fftshift
 
@@ -97,8 +97,8 @@ def backproject_2d_to_3d(
 
     # back to real space
     dft = torch.fft.ifftshift(dft, dim=(-3, -2))  # actual ifftshift
-    dft = torch.fft.irfftn(dft, dim=(-3, -2, -1))
-    dft = torch.fft.ifftshift(dft, dim=(-3, -2, -1))  # center in real space
+    dft = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=volume_shape)
+    dft = torch.fft.fftshift(dft, dim=(-3, -2, -1))  # center in real space
 
     # correct for convolution with linear interpolation kernel
     grid = fftfreq_grid(
@@ -177,7 +177,7 @@ def backproject_2d_to_3d_multichannel(
     volume_shape = (w, w, w)
 
     # calculate DFTs of images
-    images = torch.fft.fftshift(images, dim=(-2, -1))  # volume center to array origin
+    images = torch.fft.ifftshift(images, dim=(-2, -1))  # volume center to array origin
     images = torch.fft.rfftn(images, dim=(-2, -1))
     images = torch.fft.fftshift(images, dim=(-2,))  # actual fftshift
 
@@ -202,8 +202,8 @@ def backproject_2d_to_3d_multichannel(
 
     # back to real space
     dft = torch.fft.ifftshift(dft, dim=(-3, -2))  # actual ifftshift
-    dft = torch.fft.irfftn(dft, dim=(-3, -2, -1))
-    dft = torch.fft.ifftshift(dft, dim=(-3, -2, -1))  # center in real space
+    dft = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=volume_shape)
+    dft = torch.fft.fftshift(dft, dim=(-3, -2, -1))  # center in real space
 
     # correct for convolution with linear interpolation kernel
     grid = fftfreq_grid(

--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
@@ -87,7 +87,7 @@ def project_3d_to_2d(
 
     # calculate DFT
     # volume center to array origin
-    dft = torch.fft.fftshift(volume, dim=(-3, -2, -1))
+    dft = torch.fft.ifftshift(volume, dim=(-3, -2, -1))
     dft = torch.fft.rfftn(dft, dim=(-3, -2, -1))
 
     dft[..., 0, 0, 0] = 0.0  # Zero out mean to avoid low-res artifacts
@@ -122,8 +122,8 @@ def project_3d_to_2d(
 
     # transform back to real space
     projections = torch.fft.ifftshift(projections, dim=(-2,))  # ifftshift of 2D rfft
-    projections = torch.fft.irfftn(projections, dim=(-2, -1))
-    projections = torch.fft.ifftshift(
+    projections = torch.fft.irfftn(projections, dim=(-2, -1), s=volume_shape[-2:])
+    projections = torch.fft.fftshift(
         projections, dim=(-2, -1)
     )  # recenter 2D image in real space
 
@@ -216,7 +216,7 @@ def project_3d_to_2d_multichannel(
 
     # calculate DFT
     # volume center to array origin
-    dft = torch.fft.fftshift(volume, dim=(-3, -2, -1))
+    dft = torch.fft.ifftshift(volume, dim=(-3, -2, -1))
     dft = torch.fft.rfftn(dft, dim=(-3, -2, -1))
     # actual fftshift of 3D rfft
     dft = torch.fft.fftshift(dft, dim=(-3, -2))
@@ -250,8 +250,8 @@ def project_3d_to_2d_multichannel(
 
     # transform back to real space
     projections = torch.fft.ifftshift(projections, dim=(-2,))  # ifftshift of 2D rfft
-    projections = torch.fft.irfftn(projections, dim=(-2, -1))
-    projections = torch.fft.ifftshift(
+    projections = torch.fft.irfftn(projections, dim=(-2, -1), s=volume_shape[-2:])
+    projections = torch.fft.fftshift(
         projections, dim=(-2, -1)
     )  # recenter 2D image in real space
 
@@ -317,7 +317,7 @@ def project_2d_to_1d(
     image = image * torch.sinc(grid) ** 2
 
     # calculate DFT
-    dft = torch.fft.fftshift(image, dim=(-2, -1))  # image center to array origin
+    dft = torch.fft.ifftshift(image, dim=(-2, -1))  # image center to array origin
     dft = torch.fft.rfftn(dft, dim=(-2, -1))
     dft = torch.fft.fftshift(dft, dim=(-2,))  # actual fftshift of 2D rfft
 
@@ -332,8 +332,8 @@ def project_2d_to_1d(
 
     # transform back to real space
     # not needed for 1D: torch.fft.ifftshift(projections, dim=(-2,))
-    projections = torch.fft.irfftn(projections, dim=(-1))
-    projections = torch.fft.ifftshift(
+    projections = torch.fft.irfftn(projections, dim=(-1), s=image_shape[-1:])
+    projections = torch.fft.fftshift(
         projections, dim=(-1)
     )  # recenter line in real space
 

--- a/packages/primitives/torch-fourier-slice/tests/test_torch_fourier_slice.py
+++ b/packages/primitives/torch-fourier-slice/tests/test_torch_fourier_slice.py
@@ -76,6 +76,100 @@ def test_project_2d_to_1d_rotation_center(device):
     "device",
     DEVICES,
 )
+def test_project_3d_to_2d_rotation_center_odd_size(device):
+    # same as test_project_3d_to_2d_rotation_center but with an odd box size,
+    # to check that the real-space fftshift/ifftshift pair used around the
+    # forward/inverse rfft correctly centers the volume for odd sizes too
+    # (fftshift and ifftshift are only interchangeable for even sizes)
+    volume = torch.zeros((31, 31, 31), device=device)
+    volume[15, 15, 15] = 1
+
+    rotation_matrices = torch.tensor(
+        special_ortho_group.rvs(dim=3, size=100),
+        device=device,
+    )
+    projections = project_3d_to_2d(
+        volume=volume,
+        rotation_matrices=rotation_matrices,
+        pad_factor=1.0,
+    )
+
+    assert device in str(projections.device)
+    # check max is always at (15, 15), implying point (15, 15) never moves
+    for image in projections:
+        max_idx = torch.argmax(image)
+        i, j = divmod(max_idx.item(), 31)
+        assert (i, j) == (15, 15)
+
+
+@pytest.mark.parametrize(
+    "device",
+    DEVICES,
+)
+def test_project_2d_to_1d_rotation_center_odd_size(device):
+    # same as test_project_2d_to_1d_rotation_center but with an odd box size
+    image = torch.zeros((31, 31), device=device)
+    image[15, 15] = 1
+
+    rotation_matrices = torch.tensor(
+        special_ortho_group.rvs(dim=2, size=100),
+        device=device,
+    )
+    projections = project_2d_to_1d(
+        image=image,
+        rotation_matrices=rotation_matrices,
+        pad_factor=1.0,
+    )
+
+    assert device in str(projections.device)
+    # check max is always at (15), implying point (15) never moves
+    for image in projections:
+        i = torch.argmax(image)
+        assert i == 15
+
+
+@pytest.mark.parametrize(
+    "device",
+    DEVICES,
+)
+def test_3d_2d_projection_backprojection_cycle_odd_size(device):
+    # same as test_3d_2d_projection_backprojection_cycle but with an odd box
+    # size, exercising the real-space fftshift/ifftshift pair in both
+    # project_3d_to_2d and backproject_2d_to_3d for odd sizes
+    cube = torch.zeros((31, 31, 31))
+    cube[7:23, 7:23, 7:23] = 1
+    cube[15, 15, 15] = 31
+
+    rotation_matrices = torch.tensor(
+        special_ortho_group.rvs(dim=3, size=1500),
+        device=device,
+    )
+    projections = project_3d_to_2d(
+        volume=cube.to(device),
+        rotation_matrices=rotation_matrices,
+    )
+
+    # reconstruct
+    volume = backproject_2d_to_3d(
+        images=projections,
+        rotation_matrices=rotation_matrices,
+    )
+
+    assert device in str(projections.device)
+    assert device in str(volume.device)
+
+    # calculate FSC between the ground truth volume and the reconstruction
+    # odd grids have slightly different boundary interpolation behaviour than
+    # even ones, so fidelity is consistently a little lower here (~0.984-0.99
+    # across seeds) than the >0.99 achieved for the even-size cube below
+    _fsc = fsc(cube.to("cpu"), volume.float().to("cpu"))
+    assert torch.all(_fsc[-10:] > 0.98)
+
+
+@pytest.mark.parametrize(
+    "device",
+    DEVICES,
+)
 def test_3d_2d_projection_backprojection_cycle(cube, device):
     # make projections
     rotation_matrices = torch.tensor(


### PR DESCRIPTION
@mgiammar this is also a things I noticed when looking at PR #106, the fftshift and ifftshift should be swapped. It's only relevant for odd sized dimensions, which probably not a lot of people use, but it still seems important to get it correct.

Adds two fixes:
* supplies the s (shape) argument for irfftn which is needed to get the original shape back
* swaps the use off ifftshift/fftshift in real space. Shifting before taking the Fourier transform is needed to correctly place the box center at the origin. This is exactly what ifftshift (in contrast to fftshift) is intended for. So correct use is to ifftshift before and fftshift after. Note that this only matter for odd sized dimensions because the ifftshift/fftshift are identical for even sized dimensions.

I added tests that fail on main and succeed after the fixes in this branch.
