### PR TITLE
fix: evaluate Zernike aberrations against physical frequency, not normalized rho

### DIFF
--- a/packages/primitives/torch-ctf/src/torch_ctf/_ctf_core.py
+++ b/packages/primitives/torch-ctf/src/torch_ctf/_ctf_core.py
@@ -163,7 +163,7 @@ def _build_freq_grid(
         device=device,
         transform_matrix=transform_matrix,
     )
-    rho, theta = fftfreq_grid_polar(fft_freq_grid)
+    rho, theta = fftfreq_grid_polar(fft_freq_grid, normalize_rho=False)
     return fft_freq_grid, fft_freq_grid_squared, rho, theta
 
 

--- a/packages/primitives/torch-ctf/tests/test_ctf_aberrations.py
+++ b/packages/primitives/torch-ctf/tests/test_ctf_aberrations.py
@@ -8,8 +8,10 @@ from torch_ctf import (
     apply_even_zernikes,
     apply_odd_zernikes,
     beam_tilt_to_zernike_coeffs,
+    calculate_relativistic_electron_wavelength,
     resolve_odd_zernikes,
 )
+from torch_ctf._ctf_core import _build_freq_grid
 
 
 def test_beam_tilt_to_zernike_coeffs():
@@ -458,3 +460,90 @@ def test_beam_tilt_to_zernike_coeffs_broadcasting():
     assert result["Z31s"].shape == (2,)
     assert torch.all(torch.isfinite(result["Z31c"]))
     assert torch.all(torch.isfinite(result["Z31s"]))
+
+
+def test_zernike_phase_is_grid_independent():
+    """A fixed physical beam tilt must give the same aberration on any grid.
+
+    The Zernike radial coordinate carries physical units (cycles/Angstrom), so
+    the phase at a given spatial frequency must not depend on the box size or
+    pixel size used to evaluate it.
+    """
+    voltage_kv = torch.tensor(300.0, dtype=torch.float64)
+    spherical_aberration_mm = torch.tensor(2.7, dtype=torch.float64)
+    tilt_mrad = 0.5
+    beam_tilt_mrad = torch.tensor([tilt_mrad, 0.0], dtype=torch.float64)
+
+    wavelength = (
+        calculate_relativistic_electron_wavelength(voltage_kv * 1e3).double() * 1e10
+    )
+    k = 0.2  # cycles/Angstrom, inside every grid below
+    expected = (
+        2
+        * torch.pi
+        * (spherical_aberration_mm * 1e7)
+        * wavelength**2
+        * (tilt_mrad * 1e-3)
+        * k**3
+    )
+
+    coeffs = beam_tilt_to_zernike_coeffs(
+        beam_tilt_mrad=beam_tilt_mrad,
+        voltage_kv=voltage_kv,
+        spherical_aberration_mm=spherical_aberration_mm,
+    )
+
+    for image_shape, pixel_size in [((128, 128), 1.5), ((256, 256), 1.0)]:
+        _, _, rho, _ = _build_freq_grid(
+            image_shape=image_shape,
+            pixel_size=pixel_size,
+            rfft=False,
+            fftshift=True,
+            device=torch.device("cpu"),
+        )
+        # rho is a physical frequency grid, so it reaches the corner frequency
+        expected_rho_max = 0.5 * (2**0.5) / pixel_size
+        assert torch.isclose(rho.max(), torch.tensor(expected_rho_max), rtol=1e-3)
+
+        phase = apply_odd_zernikes(
+            odd_zernikes=coeffs,
+            rho=torch.tensor(k, dtype=torch.float64),
+            theta=torch.tensor(0.0, dtype=torch.float64),
+            voltage_kv=voltage_kv,
+            spherical_aberration_mm=spherical_aberration_mm,
+        )
+        assert torch.allclose(phase, expected, rtol=1e-5)
+
+
+def test_odd_zernike_matches_relion_convention():
+    """Coefficients follow RELION's rlnOddZernike convention.
+
+    RELION evaluates Zernike polynomials against unnormalized spatial
+    frequency in cycles/Angstrom (see ObservationModel::getGammaOffset), so a
+    coefficient in rad * Angstrom**n must produce coeff * k**n * trig(m*theta).
+    """
+    image_shape, pixel_size = (32, 32), 1.4
+    z33c = 1.0e4  # rad * Angstrom**3
+
+    _, _, rho, theta = _build_freq_grid(
+        image_shape=image_shape,
+        pixel_size=pixel_size,
+        rfft=False,
+        fftshift=True,
+        device=torch.device("cpu"),
+    )
+    phase = apply_odd_zernikes(
+        odd_zernikes={"Z33c": torch.tensor(z33c)},
+        rho=rho,
+        theta=theta,
+        voltage_kv=torch.tensor(300.0),
+        spherical_aberration_mm=torch.tensor(2.7),
+    )
+
+    # independently derived physical frequencies, as RELION computes them
+    freq = torch.fft.fftshift(torch.fft.fftfreq(image_shape[0], d=pixel_size))
+    ky, kx = torch.meshgrid(freq, freq, indexing="ij")
+    k_physical = torch.sqrt(kx**2 + ky**2)
+    expected = z33c * k_physical**3 * torch.cos(3 * torch.atan2(ky, kx))
+
+    assert torch.allclose(phase, expected, atol=1e-4)


### PR DESCRIPTION
I was trying to verify the different aberration terms between cryoSPARC and torch-ctf, and through Claude I came across this issue.

It looks like the Zernike radial coordinate gets normalized to `[0, 1]`, but the coefficients going into it are calibrated against physical frequency in cycles/Å. So beam-tilt coma comes out scaled by `1 / rho_max**3`, which varies with box size and pixel size. The line is in `_ctf_core.py`:

```python
rho, theta = fftfreq_grid_polar(fft_freq_grid)   # normalize_rho defaults to True
```

Is this accidental? Two things make me think it might be: `_build_freq_grid`'s docstring already says `rho : ... in cycles/Angstrom`, and `beam_tilt_to_zernike_coeffs` builds its prefactor as `2 * C.pi * Cs * lam**2` with both in Å — that's a rad·Å³ coefficient, so it wants a physical `k**3`. Those two can't both be right as they stand.

RELION also uses physical k here: `obs_model.cpp` computes `xx0 = x / (angpix * boxSize)` and hands it to `Zernike::Z_cart`, which doesn't renormalize. So `rlnOddZernike`/`rlnEvenZernike` are in rad·Å^n and can't currently be passed to torch-ctf as-is. cryoSPARC's basis is physical too.

Same beam tilt (0.5 mrad, Cs 2.7 mm, 300 kV) sampled at k = 0.2 cycles/Å on three grids, against the standard `2*pi*Cs*lambda**2*tilt*k**3`:

```
(128, 128) 1.5 A/px:   expected 0.263017  got 2.510746  ratio 9.546
(256, 256) 1.0 A/px:   expected 0.263017  got 0.743925  ratio 2.828
(384, 384) 0.65 A/px:  expected 0.263017  got 0.204300  ratio 0.777
```

The ratio is `1 / rho_max**3` every time, and it crosses 1.0, so you can't fold it into a constant. At 0.5 mrad the error is over a cycle of phase, so zeros actually move.

Fix is one line:

```diff
-    rho, theta = fftfreq_grid_polar(fft_freq_grid)
+    rho, theta = fftfreq_grid_polar(fft_freq_grid, normalize_rho=False)
```

`rho` only feeds `apply_odd_zernikes` and `apply_even_zernikes`, so nothing else depends on its scale, and `beam_tilt_to_zernike_coeffs` becomes correct as written. After the change all three grids give `0.263017`, matching RELION's `TiltHelper::insertTilt` too (opposite sign, since RELION stores the conjugate correction).

Do let me know if I've misunderstood, and users are meant to scale their coefficients into the normalized convention themselves. In that case the fix probably belongs in `beam_tilt_to_zernike_coeffs` instead then!
