### PR TITLE
feat: support Z42c/Z42s (secondary astigmatism) in apply_even_zernikes

### DIFF
--- a/packages/primitives/torch-ctf/src/torch_ctf/ctf_aberrations.py
+++ b/packages/primitives/torch-ctf/src/torch_ctf/ctf_aberrations.py
@@ -308,8 +308,11 @@ def apply_even_zernikes(
     Parameters
     ----------
     even_zernikes: dict
-        Even Zernike coefficients. Values can be floats or tensors.
-        Floats will be converted to tensors for differentiability.
+        Even Zernike coefficients, keyed by name. Supported names are
+        ``Z42c``/``Z42s`` (secondary astigmatism), ``Z44c``/``Z44s``
+        (four-fold astigmatism) and ``Z60`` (sixth-order spherical).
+        Values can be floats or tensors. Floats will be converted to
+        tensors for differentiability.
     total_phase_shift: torch.Tensor
         Total phase shift.
     rho: torch.Tensor
@@ -338,7 +341,11 @@ def apply_even_zernikes(
                 f"Zernike coefficient must be float or torch.Tensor, got {type(coeff)}"
             )
 
-        if name == "Z44c":  # 4-fold astigmatism
+        if name == "Z42c":  # secondary (2-fold) astigmatism
+            chi += coeff * rho**4 * torch.cos(2 * theta)
+        elif name == "Z42s":
+            chi += coeff * rho**4 * torch.sin(2 * theta)
+        elif name == "Z44c":  # 4-fold astigmatism
             chi += coeff * rho**4 * torch.cos(4 * theta)
         elif name == "Z44s":
             chi += coeff * rho**4 * torch.sin(4 * theta)

--- a/packages/primitives/torch-ctf/tests/test_ctf_aberrations.py
+++ b/packages/primitives/torch-ctf/tests/test_ctf_aberrations.py
@@ -547,3 +547,22 @@ def test_odd_zernike_matches_relion_convention():
     expected = z33c * k_physical**3 * torch.cos(3 * torch.atan2(ky, kx))
 
     assert torch.allclose(phase, expected, atol=1e-4)
+
+
+def test_apply_even_zernikes_secondary_astigmatism():
+    """Z42c/Z42s share the Z44 radial form with cos/sin(2*theta)."""
+    even_zernikes = {"Z42c": torch.tensor(0.1), "Z42s": torch.tensor(0.2)}
+    total_phase_shift = torch.zeros((10, 10))
+    rho = torch.full((10, 10), 0.5)
+    theta = torch.linspace(0, 2 * torch.pi, 100).reshape(10, 10)
+
+    result = apply_even_zernikes(
+        even_zernikes=even_zernikes,
+        total_phase_shift=total_phase_shift,
+        rho=rho,
+        theta=theta,
+    )
+    expected = 0.1 * rho**4 * torch.cos(2 * theta) + 0.2 * rho**4 * torch.sin(2 * theta)
+
+    assert torch.allclose(result, expected)
+    assert torch.all(torch.isfinite(result))


### PR DESCRIPTION
Following on from #111, still comparing cryoSPARC's aberration terms against torch-ctf.

I noticed `apply_even_zernikes` covers `Z44c`/`Z44s` and `Z60`, but there's nothing for the `n=4, m=±2` pair (secondary astigmatism) — passing it just raises `Unknown even Zernike`.

cryoSPARC gives you a four-component `ctf/tetra_A` per exposure group. Two of them are the `m=±4` terms and map onto `Z44c`/`Z44s` fine, but the other two are `m=±2` and there's nowhere to put them at the moment. I checked the whole set against cryoSPARC's simulator output and the basis is `k**4*cos(2θ)`, `k**4*sin(2θ)`, `k**4*cos(4θ)`, `k**4*sin(4θ)`, so the missing pair is just the `Z44` branch with `2*theta` instead of `4*theta`:

```diff
-        if name == "Z44c":  # 4-fold astigmatism
+        if name == "Z42c":  # secondary (2-fold) astigmatism
+            chi += coeff * rho**4 * torch.cos(2 * theta)
+        elif name == "Z42s":
+            chi += coeff * rho**4 * torch.sin(2 * theta)
+        elif name == "Z44c":  # 4-fold astigmatism
             chi += coeff * rho**4 * torch.cos(4 * theta)
```

Also added the supported names to the docstring, since I couldn't find them written down anywhere.

One test, following the existing `apply_even_zernikes` ones.
