### PR TITLE
fix(torch-fourier-slice) use edge subtraction before extraction

### DIFF
--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
@@ -9,7 +9,7 @@ from .slice_extraction import (
     transform_slice_2d,
     transform_slice_2d_multichannel,
 )
-from .volume_utils import compute_cube_face_averages
+from .volume_utils import compute_cube_face_averages, compute_square_edge_averages
 
 
 def project_3d_to_2d(
@@ -75,11 +75,14 @@ def project_3d_to_2d(
     if pad_factor < 1.0:
         raise ValueError("pad_factor must be >= 1.0")
 
-    # Apply edge padding to the nearest integer matching the desired pad_factor
+    # Subtract the edge value so the padded region continues smoothly from zero
+    edge_value = compute_cube_face_averages(volume, n=4)  # NOTE: 4 is arbitrary
+    volume = volume - edge_value
+
+    # Apply zero padding to the nearest integer matching the desired pad_factor
     if pad_factor > 1.0:
         p = int((w * (pad_factor - 1.0)) // 2)
-        edge_value = compute_cube_face_averages(volume, n=4)  # 4 is arbitrary
-        volume = F.pad(volume, pad=[p] * 6, mode="constant", value=edge_value)
+        volume = F.pad(volume, pad=[p] * 6, mode="constant", value=0.0)
 
     volume_shape = tuple(volume.shape[-3:])
 
@@ -141,7 +144,10 @@ def project_3d_to_2d(
 
     # unpad
     if pad_factor > 1.0:
-        projections = F.pad(projections, pad=[-p] * 4)
+        projections = F.pad(projections, pad=[-p] * 4, mode="constant", value=0.0)
+
+    # add the edge value back, scaled to the unpadded box size
+    projections = projections + edge_value * d
 
     return projections
 
@@ -207,9 +213,13 @@ def project_3d_to_2d_multichannel(
     if pad_factor < 1.0:
         raise ValueError("pad_factor must be >= 1.0")
 
+    # Subtract the (per-channel) edge value so the padded region continues smoothly
+    edge_value = compute_cube_face_averages(volume, n=4)  # (c,)
+    volume = volume - edge_value[..., None, None, None]
+
     if pad_factor > 1.0:
         p = int((volume.shape[-1] * (pad_factor - 1.0)) // 2)
-        volume = F.pad(volume, pad=[p] * 6)
+        volume = F.pad(volume, pad=[p] * 6, mode="constant", value=0.0)
 
     # set the shape as a variable
     volume_shape = tuple(volume.shape[-3:])
@@ -273,7 +283,10 @@ def project_3d_to_2d_multichannel(
 
     # unpad
     if pad_factor > 1.0:
-        projections = F.pad(projections, pad=[-p] * 4)
+        projections = F.pad(projections, pad=[-p] * 4, mode="constant", value=0.0)
+
+    # add the (per-channel) edge value back, scaled to the unpadded box size
+    projections = projections + edge_value[..., None, None] * d
 
     return projections
 
@@ -317,9 +330,13 @@ def project_2d_to_1d(
     if pad_factor < 1.0:
         raise ValueError("pad_factor must be >= 1.0")
 
+    # Subtract the edge value so the padded region continues smoothly from zero
+    edge_value = compute_square_edge_averages(image, n=4)  # NOTE: 4 is arbitrary
+    image = image - edge_value
+
     if pad_factor > 1.0:
         p = int((image.shape[-1] * (pad_factor - 1.0)) // 2)
-        image = F.pad(image, pad=[p] * 4)
+        image = F.pad(image, pad=[p] * 4, mode="constant", value=0.0)
 
     # set the shape as a variable
     image_shape = tuple(image.shape[-2:])
@@ -361,6 +378,9 @@ def project_2d_to_1d(
 
     # unpad
     if pad_factor > 1.0:
-        projections = F.pad(projections, pad=[-p] * 2)
+        projections = F.pad(projections, pad=[-p] * 2, mode="constant", value=0.0)
+
+    # add the edge value back, scaled to the unpadded box size
+    projections = projections + edge_value * w
 
     return projections

--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/volume_utils.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/volume_utils.py
@@ -1,36 +1,88 @@
 import torch
 
 
-def compute_cube_face_averages(volume: torch.Tensor, n: int = 1) -> float:
+def boundary_shell_average(
+    volume: torch.Tensor, n: int, n_spatial_dims: int
+) -> torch.Tensor:
+    """Average of `n` voxels/pixels from rectangular boundary, handling batch/channels.
+
+    Parameters
+    ----------
+    volume: torch.Tensor
+        `(..., d, d)` or `(..., d, d, d)` volume, optionally with leading batch/channel
+        dimensions.
+    n: int
+        Number of voxels/pixels from the boundary to include in the average.
+    n_spatial_dims: int
+        Number of spatial dimensions in the volume.
+
+    Returns
+    -------
+    torch.Tensor
+        `(...)` average value of `n` voxels/pixels from the boundary,
+        one value per leading batch/channel element (0-dim if `volume` is `(d, d)`
+        or `(d, d, d)`).
+    """
+    spatial_shape = volume.shape[-n_spatial_dims:]
+    d = spatial_shape[0]
+
+    assert n >= 1, "n must be >= 1"
+    assert len(set(spatial_shape)) == 1, "all spatial dimensions must be equal."
+    assert n < d // 2, "n must be less than half the spatial size."
+
+    spatial_dims = tuple(range(-n_spatial_dims, 0))
+    interior_slice = (Ellipsis,) + (slice(n, -n),) * n_spatial_dims
+    interior = volume[interior_slice]
+
+    total_sum = volume.sum(dim=spatial_dims)
+    total_elements = 1
+    for s in spatial_shape:
+        total_elements *= s
+
+    interior_sum = interior.sum(dim=spatial_dims)
+    interior_elements = 1
+    for s in interior.shape[-n_spatial_dims:]:
+        interior_elements *= s
+
+    shell_sum = total_sum - interior_sum
+    shell_elements = total_elements - interior_elements
+
+    return shell_sum / shell_elements
+
+
+def compute_cube_face_averages(volume: torch.Tensor, n: int = 1) -> torch.Tensor:
     """Get the average value of all voxels within n-voxels of the cube faces.
 
     Parameters
     ----------
     volume: torch.Tensor
-        `(d, d, d)` volume.
+        `(..., d, d, d)` volume, optionally with leading batch/channel dims.
     n: int
         Number of voxels from the cube faces to include in the average.
 
     Returns
     -------
-    float
-        Average value of all voxels within n-voxels of the cube faces.
+    torch.Tensor
+        `(...)` average value of all voxels within n-voxels of the cube faces,
+        one value per leading batch/channel element (0-dim if `volume` is `(d, d, d)`).
     """
-    d, h, w = volume.shape[-3:]
+    return boundary_shell_average(volume, n=n, n_spatial_dims=3)
 
-    assert n >= 1, "n must be >= 1"
-    assert len({d, h, w}) == 1, "all dimensions of volume must be equal."
-    assert n < d // 2, "n must be less than half the volume size."
 
-    total_sum = volume.sum()
-    total_voxels = volume.numel()
+def compute_square_edge_averages(image: torch.Tensor, n: int = 1) -> torch.Tensor:
+    """Get the average value of all pixels within n-pixels of the square edges.
 
-    # Get the sum of the interior of the cube to avoid double counting
-    interior = volume[n:-n, n:-n, n:-n]
-    interior_sum = interior.sum()
-    interior_voxels = interior.numel()
+    Parameters
+    ----------
+    image: torch.Tensor
+        `(..., d, d)` image, optionally with leading batch/channel dims.
+    n: int
+        Number of pixels from the square edges to include in the average.
 
-    face_sum = total_sum - interior_sum
-    face_voxels = total_voxels - interior_voxels
-
-    return float((face_sum / face_voxels).item())
+    Returns
+    -------
+    torch.Tensor
+        `(...)` average value of all pixels within n-pixels of the square edges,
+        one value per leading batch/channel element (0-dim if `image` is `(d, d)`).
+    """
+    return boundary_shell_average(image, n=n, n_spatial_dims=2)


### PR DESCRIPTION
@McHaillet @jdickerson95 

Updated code here to subtract the edge off the volume before padding (and use zero padding) rather than tracking the mean value and setting DC to zero in the FFT. The inward number of pixels/voxels the mean is averaged over is set to 4, but is an arbitrary choice.

Mean absolute errors improve significantly for some random Gaussian blobs where there is some non-zero background value added to the volume

```
C=  0.0  naive MAE from C*d =   0.0000   current MAE from C*d =   0.0000
C=  0.1  naive MAE from C*d =   0.8219   current MAE from C*d =   0.0000
C=  1.0  naive MAE from C*d =   8.2188   current MAE from C*d =   0.0000
C=  5.0  naive MAE from C*d =  41.0938   current MAE from C*d =   0.0000
C= 20.0  naive MAE from C*d = 164.3752   current MAE from C*d =   0.0000
C= 98.8  naive MAE from C*d = 811.6771   current MAE from C*d =   0.0005
```
<img width="590" height="390" alt="image" src="https://github.com/user-attachments/assets/0ccacf02-c5d0-4490-b168-582fb1cc9672" />
