### PR TITLE
Performance improvement to `torch-motion-correction`/`torch-fourier-filter` for large movies

### DIFF
--- a/packages/algorithms/torch-motion-correction/README.md
+++ b/packages/algorithms/torch-motion-correction/README.md
@@ -6,9 +6,13 @@
 [![CI](https://github.com/teamtomo/torch-motion-correction/actions/workflows/ci.yml/badge.svg)](https://github.com/teamtomo/torch-motion-correction/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/teamtomo/torch-motion-correction/branch/main/graph/badge.svg)](https://codecov.io/gh/teamtomo/torch-motion-correction)
 
-Motion estimation and correction in PyTorch.
+Movie motion estimation and correction using PyTorch. Implements a spline-based deformation field to model the beam-induced motion over movie collection.
 
-work in progress
+## Implemented algorithms
+
+- Cross-correlation-based global motion estimation (see `estimate_global_motion` in [estimate_motion_xc.py](src/torch_motion_correction/estimate_motion_xc.py))
+- Spline-based local motion estimation (see `estimate_local_motion` in [estimate_motion_optimizer.py](src/torch_motion_correction/estimate_motion_optimizer.py))
+- Motion correction of movie (not summation to final micrograph) using estimated deformation field (see `correct_motion` in [correct_motion.py](src/torch_motion_correction/correct_motion.py))
 
 ## Authors
 

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/correct_motion.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/correct_motion.py
@@ -48,9 +48,15 @@ def correct_motion(
     image = image.to(device)
     deformation_field = deformation_field.to(device)
 
-    t, _, _ = image.shape
+    t, h, w = image.shape
     _, _, gh, gw = deformation_field.data.shape
     normalized_t = torch.linspace(0, 1, steps=t, device=image.device)
+
+    # Grid depends only on (h, w, device). Compute only once outside per-frame loop.
+    pixel_grid = coordinate_grid(
+        image_shape=(h, w),
+        device=image.device,
+    )  # (h, w, 2) yx coords
 
     # Use conditional gradient context to save memory
     gradient_context = torch.enable_grad() if grad else torch.no_grad()
@@ -65,6 +71,7 @@ def correct_motion(
                     grid_shape=(10 * gh, 10 * gw),
                 ),
                 pixel_spacing=pixel_spacing,
+                pixel_grid=pixel_grid,
             )
             for frame, frame_t in zip(image, normalized_t)
         ]
@@ -76,6 +83,7 @@ def _correct_frame(
     frame: torch.Tensor,
     pixel_spacing: float,
     frame_deformation_grid: torch.Tensor,  # (yx, h, w)
+    pixel_grid: torch.Tensor,
 ) -> torch.Tensor:
     """Correct a single frame using a deformation grid.
 
@@ -87,21 +95,14 @@ def _correct_frame(
         Pixel spacing in Angstroms
     frame_deformation_grid: torch.Tensor
         (yx, h, w) deformation grid
+    pixel_grid: torch.Tensor
+        (h, w, 2) yx pixel coordinate grid.
 
     Returns
     -------
     corrected_frame: torch.Tensor
         (h, w) corrected frame
     """
-    # grab frame and deformation grid dimensions
-    h, w = frame.shape
-
-    # prepare a grid of pixel positions
-    pixel_grid = coordinate_grid(
-        image_shape=(h, w),
-        device=frame.device,
-    )  # (h, w, 2) yx coords
-
     pixel_shifts = get_pixel_shifts(
         frame=frame,
         pixel_spacing=pixel_spacing,
@@ -217,13 +218,19 @@ def correct_motion_two_grids(
     new_deformation_field = new_deformation_field.to(device)
     base_deformation_field = base_deformation_field.to(device)
 
-    t, _, _ = image.shape
+    t, h, w = image.shape
 
     # Derive oversampled grid resolution from the deformation field
     _, _nt, nh, nw = new_deformation_field.data.shape
     gh, gw = nh, nw
 
     normalized_t = torch.linspace(0, 1, steps=t, device=device)
+
+    # Grid depends only on (h, w, device). Compute only once outside per-frame loop.
+    pixel_grid = coordinate_grid(
+        image_shape=(h, w),
+        device=device,
+    )  # (h, w, 2) yx coords
 
     gradient_context = torch.enable_grad() if grad else torch.no_grad()
 
@@ -236,6 +243,7 @@ def correct_motion_two_grids(
                 frame_t=frame_t,
                 grid_shape=(10 * gh, 10 * gw),
                 pixel_spacing=pixel_spacing,
+                pixel_grid=pixel_grid,
             )
             for frame, frame_t in zip(image, normalized_t)
         ]
@@ -252,6 +260,7 @@ def _correct_frame_two_grids(
     frame_t: float,
     grid_shape: tuple[int, int],
     pixel_spacing: float,
+    pixel_grid: torch.Tensor,
 ) -> torch.Tensor:
     """Correct a single frame using two deformation fields.
 
@@ -269,6 +278,8 @@ def _correct_frame_two_grids(
         (h, w) shape of the grid to evaluate at
     pixel_spacing: float
         Pixel spacing in Angstroms
+    pixel_grid: torch.Tensor
+        (h, w, 2) yx pixel coordinate grid.
 
     Returns
     -------
@@ -297,6 +308,7 @@ def _correct_frame_two_grids(
         frame=frame,
         frame_deformation_grid=combined_shifts,
         pixel_spacing=pixel_spacing,
+        pixel_grid=pixel_grid,
     )
 
     return corrected_frame
@@ -333,8 +345,14 @@ def correct_motion_slow(
     image = image.to(device)
     deformation_field = deformation_field.to(device)
 
-    t, _, _ = image.shape
+    t, h, w = image.shape
     normalized_t = torch.linspace(0, 1, steps=t, device=image.device)
+
+    # Grid depends only on (h, w, device). Compute only once outside per-frame loop.
+    pixel_grid = coordinate_grid(
+        image_shape=(h, w),
+        device=image.device,
+    )  # (h, w, 2) yx coords
 
     # Use conditional gradient context to save memory
     gradient_context = torch.enable_grad() if grad else torch.no_grad()
@@ -346,6 +364,7 @@ def correct_motion_slow(
                 frame=frame,
                 deformation_grid=deformation_field.data,
                 t=frame_t,
+                pixel_grid=pixel_grid,
             )
             for frame, frame_t in zip(image, normalized_t)
         ]
@@ -357,6 +376,7 @@ def _correct_frame_slow(
     frame: torch.Tensor,
     deformation_grid: torch.Tensor,
     t: float,  # [0, 1]
+    pixel_grid: torch.Tensor,
 ) -> torch.Tensor:
     """Correct a single frame using a deformation grid.
 
@@ -368,6 +388,8 @@ def _correct_frame_slow(
         (yx, h, w) deformation grid
     t: float
         Timepoint to evaluate at [0, 1]
+    pixel_grid: torch.Tensor
+        (h, w, 2) yx pixel coordinate grid.
 
     Returns
     -------
@@ -376,12 +398,6 @@ def _correct_frame_slow(
     """
     # grab frame dimensions
     h, w = frame.shape
-
-    # prepare a grid of pixel positions
-    pixel_grid = coordinate_grid(
-        image_shape=(h, w),
-        device=frame.device,
-    )  # (h, w, 2) yx coords
 
     dim_lengths = torch.as_tensor(
         [h - 1, w - 1], device=frame.device, dtype=torch.float32

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/correct_motion.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/correct_motion.py
@@ -441,7 +441,8 @@ def correct_motion_fast(
     Parameters
     ----------
     image: torch.Tensor
-        (t, h, w) array of images to motion correct
+        (t, h, w) array of images to motion correct. May reside on a different
+        device than ``device`` (e.g. large super-res movie stored on CPU).
     deformation_field: DeformationField
         Deformation field with shape (2, t, 1, 1) in Angstroms.
     device: torch.device, optional
@@ -452,12 +453,11 @@ def correct_motion_fast(
     Returns
     -------
     corrected_frames: torch.Tensor
-        (t, h, w) corrected images
+        (t, h, w) corrected images, on the same device as the input ``image``.
     """
     if device is None:
         device = image.device
 
-    image = image.to(device)
     deformation_field = deformation_field.to(device)
 
     # Check that deformation field has single patch dimensions
@@ -470,9 +470,12 @@ def correct_motion_fast(
 
     t, h, w = image.shape
 
-    # Extract shifts from deformation field (2, t, 1, 1) -> (t, 2)
-    shifts = einops.rearrange(deformation_field.data, "c t 1 1 -> t c")
-    shifts *= -1  # flip for phase shift
+    # Extract shifts from deformation field (2, t, 1, 1) -> (t, 2). Negation
+    # must be out-of-place: `deformation_field.to(device)` is a no-op (shares
+    # storage with the caller's tensor) when already on `device`, so an
+    # in-place `*= -1` here would silently flip the sign of the caller's
+    # deformation field.
+    shifts = -einops.rearrange(deformation_field.data, "c t 1 1 -> t c")
 
     if verbose:
         print(f"Single patch correction: applying shifts to {t} frames")
@@ -481,16 +484,19 @@ def correct_motion_fast(
             f"x=[{shifts[:, 1].min():.2f}, {shifts[:, 1].max():.2f}] pixels"
         )
 
-    image_fft = torch.fft.rfftn(image, dim=(-2, -1))  # (t, h, w_freq)
+    corrected_frames = torch.empty((t, h, w), dtype=image.dtype, device=image.device)
 
-    shifted_fft = fourier_shift_dft_2d(
-        dft=image_fft,
-        image_shape=(h, w),
-        shifts=shifts,  # (t, 2) shifts
-        rfft=True,
-        fftshifted=False,
-    )
+    for frame_idx in range(t):
+        frame = image[frame_idx].to(device)
+        frame_fft = torch.fft.rfftn(frame, dim=(-2, -1))
+        shifted_fft = fourier_shift_dft_2d(
+            dft=frame_fft,
+            image_shape=(h, w),
+            shifts=shifts[frame_idx],
+            rfft=True,
+            fftshifted=False,
+        )
+        corrected_frame = torch.fft.irfftn(shifted_fft, s=(h, w))
+        corrected_frames[frame_idx] = corrected_frame.to(image.device)
 
-    corrected_frames = torch.fft.irfftn(shifted_fft, s=(h, w))
-
-    return corrected_frames
+    return corrected_frames  # (t, h, w), on image.device

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/correct_motion.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/correct_motion.py
@@ -23,7 +23,8 @@ def correct_motion(
     Parameters
     ----------
     image: torch.Tensor
-        (t, h, w) array of images to motion correct
+        (t, h, w) array of images to motion correct. May reside on different device than
+        specified compute 'device' (e.g. large super-res movie stored on CPU).
     deformation_field: DeformationField
         Spatiotemporal deformation field with shape (2, nt, nh, nw) in Angstroms.
         The ``grid_type`` attribute of the
@@ -34,37 +35,39 @@ def correct_motion(
     grad: bool
         Whether to enable gradients. Default is False.
     device: torch.device, optional
-        Device for computation. Default is None, which uses the device of the
-        input image.
+        Device for computation. Default is None, which uses the device of the input
+        image.
 
     Returns
     -------
     corrected_frames: torch.Tensor
-        (t, h, w) corrected images
+        (t, h, w) corrected images, on the same device as the input ``image``.
     """
     if device is None:
         device = image.device
 
-    image = image.to(device)
     deformation_field = deformation_field.to(device)
 
     t, h, w = image.shape
     _, _, gh, gw = deformation_field.data.shape
-    normalized_t = torch.linspace(0, 1, steps=t, device=image.device)
+    normalized_t = torch.linspace(0, 1, steps=t, device=device)
 
     # Grid depends only on (h, w, device). Compute only once outside per-frame loop.
     pixel_grid = coordinate_grid(
         image_shape=(h, w),
-        device=image.device,
+        device=device,
     )  # (h, w, 2) yx coords
+
+    corrected_frames = torch.empty((t, h, w), dtype=image.dtype, device=image.device)
 
     # Use conditional gradient context to save memory
     gradient_context = torch.enable_grad() if grad else torch.no_grad()
 
     with gradient_context:
         # correct motion in each frame
-        corrected_frames = [
-            _correct_frame(
+        for frame_idx, frame_t in enumerate(normalized_t):
+            frame = image[frame_idx].to(device)
+            corrected_frame = _correct_frame(
                 frame=frame,
                 frame_deformation_grid=deformation_field.evaluate_at_t(
                     t=frame_t,
@@ -73,10 +76,9 @@ def correct_motion(
                 pixel_spacing=pixel_spacing,
                 pixel_grid=pixel_grid,
             )
-            for frame, frame_t in zip(image, normalized_t)
-        ]
-    corrected_frames = torch.stack(corrected_frames, dim=0).detach()
-    return corrected_frames  # (t, h, w)
+            corrected_frames[frame_idx] = corrected_frame.detach().to(image.device)
+
+    return corrected_frames  # (t, h, w), on image.device
 
 
 def _correct_frame(

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
@@ -1,23 +1,159 @@
 """Estimate local motion using a deformation field."""
 
-from collections.abc import Callable
+import random
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from typing import Any, cast
 
 import einops
 import torch
 import torch.utils.checkpoint as checkpoint
 import tqdm
+from torch_fourier_rescale import fourier_rescale_2d
 from torch_fourier_shift import fourier_shift_dft_2d
 
 from torch_motion_correction.deformation_field import DeformationField
 from torch_motion_correction.optimization_state import OptimizationTracker
-from torch_motion_correction.patch_utils import ImagePatchIterator
 from torch_motion_correction.types import (
     FourierFilterConfig,
     OptimizationConfig,
     PatchSamplingConfig,
 )
 from torch_motion_correction.utils import normalize_image, prepare_patch_filters
+
+
+@dataclass
+class _PrecomputedPatchState:
+    """Iteration-invariant state prepared once before the optimization loop."""
+
+    new_deformation_field: DeformationField
+    base_deformation_field: DeformationField
+    cached_fft: torch.Tensor  # (n_patches, t, ph, pw//2+1)
+    centers_norm: torch.Tensor  # (t, n_patches, 3)
+    base_shifts_cache: torch.Tensor  # (t, n_patches, 2), detached
+    b_factor_envelope: torch.Tensor | None  # (ph, pw//2+1)
+    bandpass_filter: torch.Tensor | None  # (ph, pw//2+1)
+    pixel_spacing: float  # possibly Fourier-cropped
+    ph: int  # possibly Fourier-cropped
+    pw: int  # possibly Fourier-cropped
+
+
+def _prepare_patch_state(
+    image: torch.Tensor,  # (t, H, W)
+    pixel_spacing: float,
+    deformation_field_resolution: tuple[int, int, int],
+    patch_sampling: PatchSamplingConfig,
+    fourier_filter: FourierFilterConfig,
+    grid_type: str,
+    initial_deformation_field: DeformationField | None,
+    device: torch.device,
+) -> _PrecomputedPatchState:
+    """Extract, mask, Fourier-crop, and cache all patches once.
+
+    Notes
+    -----
+    Move is static across entire optimization which means patch extraction plus any
+    masking and filtering operations can happen once rather than within optimization
+    loop. Additionally, band-pass filtering zeros many pixels in Fourier space. Can crop
+    down to new resolution (``fourier_filter.frequency_range[1]``) without losing any
+    information to dramatically speed up per-iteration work.
+
+    Parameters
+    ----------
+    image : torch.Tensor
+        (t, H, W) movie, already moved to ``device``. Normalized internally.
+    pixel_spacing : float
+        Pixel spacing in Angstroms.
+    deformation_field_resolution : tuple[int, int, int]
+        Resolution of the deformation field (nt, nh, nw).
+    patch_sampling : PatchSamplingConfig
+        Patch extraction configuration.
+    fourier_filter : FourierFilterConfig
+        Fourier-space filtering parameters (b_factor and frequency_range).
+    grid_type : str
+        Cubic spline interpolation type for the deformation field.
+    initial_deformation_field : DeformationField | None
+        Initial deformation field to start from. If None, initializes to zero.
+    device : torch.device
+        Device to perform computation on.
+
+    Returns
+    -------
+    _PrecomputedPatchState
+        Bundle of precomputed, iteration-invariant tensors and the two
+        deformation fields (frozen base + optimizable increment).
+    """
+    patch_shape = patch_sampling.patch_shape
+    ph, pw = patch_shape
+
+    image = normalize_image(image)
+    image_patch_iterator = patch_sampling.get_patch_iterator(image=image, device=device)
+
+    new_deformation_field, base_deformation_field = DeformationField.from_initial_field(
+        resolution=deformation_field_resolution,
+        initial_field=initial_deformation_field,
+        grid_type=grid_type,
+        device=device,
+    )
+
+    # Real-space apodization mask at full (uncropped) resolution
+    circle_mask, _, _ = prepare_patch_filters(
+        shape=patch_shape,
+        pixel_spacing=pixel_spacing,
+        fourier_filter=fourier_filter,
+        mask_smoothing_fraction=1.0,  # optimizer historically uses radius == smoothing
+        device=device,
+    )
+
+    n_patches = (
+        image_patch_iterator.control_points.shape[1]
+        * image_patch_iterator.control_points.shape[2]
+    )
+    all_patches, all_centers_norm = next(
+        iter(image_patch_iterator.get_iterator(batch_size=n_patches, randomized=False))
+    )  # (n_patches, t, ph, pw), (t, n_patches, 3)
+    masked_patches = all_patches * circle_mask
+
+    # Find maximum resolution in the band-pass filter to re-scale patches
+    crop_pixel_spacing = fourier_filter.frequency_range[1] / 2
+    if crop_pixel_spacing > pixel_spacing:
+        cached_patches, new_spacing = fourier_rescale_2d(
+            masked_patches,
+            source_spacing=pixel_spacing,
+            target_spacing=crop_pixel_spacing,
+        )
+        ph_eff, pw_eff = cached_patches.shape[-2:]
+        pixel_spacing_eff = new_spacing[0]
+    else:
+        cached_patches = masked_patches
+        ph_eff, pw_eff = ph, pw
+        pixel_spacing_eff = pixel_spacing
+
+    # Fourier filters, rebuilt at the (possibly cropped) resolution/spacing.
+    _, b_factor_envelope, bandpass_filter = prepare_patch_filters(
+        shape=(ph_eff, pw_eff),
+        pixel_spacing=pixel_spacing_eff,
+        fourier_filter=fourier_filter,
+        mask_smoothing_fraction=1.0,
+        device=device,
+    )
+
+    cached_fft = torch.fft.rfftn(cached_patches, dim=(-2, -1))
+    with torch.no_grad():
+        base_shifts_cache = base_deformation_field(all_centers_norm).detach()
+
+    return _PrecomputedPatchState(
+        new_deformation_field=new_deformation_field,
+        base_deformation_field=base_deformation_field,
+        cached_fft=cached_fft,
+        centers_norm=all_centers_norm,
+        base_shifts_cache=base_shifts_cache,
+        b_factor_envelope=b_factor_envelope,
+        bandpass_filter=bandpass_filter,
+        pixel_spacing=pixel_spacing_eff,
+        ph=ph_eff,
+        pw=pw_eff,
+    )
 
 
 def estimate_local_motion(
@@ -72,10 +208,6 @@ def estimate_local_motion(
         optimization = OptimizationConfig()
 
     # Deconstruct config objects
-    patch_shape = patch_sampling.patch_shape
-    ph, pw = patch_shape
-    # b_factor = fourier_filter.b_factor
-    # frequency_range = fourier_filter.frequency_range
     max_iterations = optimization.max_iterations
     optimizer_type = optimization.optimizer_type
     loss_type = optimization.loss_type
@@ -91,27 +223,20 @@ def estimate_local_motion(
     trajectory_kwargs.setdefault("total_steps", max_iterations)
     trajectory = OptimizationTracker(**trajectory_kwargs)
 
-    # Normalize image based on stats from central 50% of image
-    image = normalize_image(image)
-
-    # Create the patch grid via PatchSamplingConfig
-    image_patch_iterator = patch_sampling.get_patch_iterator(image=image, device=device)
-
-    new_deformation_field, deformation_field = DeformationField.from_initial_field(
-        resolution=deformation_field_resolution,
-        initial_field=initial_deformation_field,
-        grid_type=grid_type,
-        device=device,
-    )
-
-    # Reusable masks and Fourier filters
-    circle_mask, b_factor_envelope, bandpass_filter = prepare_patch_filters(
-        shape=patch_shape,
+    # NOTE: All patch extraction, masking, Fourier-cropping, and filter/cache setup is
+    # iteration-invariant, so compute once into data object
+    state = _prepare_patch_state(
+        image=image,
         pixel_spacing=pixel_spacing,
+        deformation_field_resolution=deformation_field_resolution,
+        patch_sampling=patch_sampling,
         fourier_filter=fourier_filter,
-        mask_smoothing_fraction=1.0,  # optimizer historically uses radius == smoothing
+        grid_type=grid_type,
+        initial_deformation_field=initial_deformation_field,
         device=device,
     )
+    new_deformation_field = state.new_deformation_field
+    deformation_field = state.base_deformation_field
 
     motion_optimizer = _setup_optimizer(
         optimizer_type=optimizer_type,
@@ -136,20 +261,20 @@ def estimate_local_motion(
 
     # Helper inner function to to have all other arguments fixed
     def process_batch(
-        patch_batch: torch.Tensor,
+        fft_batch: torch.Tensor,
         patch_batch_centers: torch.Tensor,
+        base_shifts_batch: torch.Tensor,
     ) -> torch.Tensor:
         return _process_patch_batch(
-            patch_batch=patch_batch,
+            fft_batch=fft_batch,
             patch_batch_centers=patch_batch_centers,
-            circle_mask=circle_mask,
-            b_factor_envelope=b_factor_envelope,
-            bandpass=bandpass_filter,
-            base_deformation_field=deformation_field,
+            base_shifts_batch=base_shifts_batch,
+            b_factor_envelope=state.b_factor_envelope,
+            bandpass=state.bandpass_filter,
             new_deformation_field=new_deformation_field,
-            pixel_spacing=pixel_spacing,
-            ph=ph,
-            pw=pw,
+            pixel_spacing=state.pixel_spacing,
+            ph=state.ph,
+            pw=state.pw,
             loss_type=loss_type,
             t=t,
         )
@@ -161,7 +286,9 @@ def estimate_local_motion(
         if optimizer_type.lower() == "lbfgs":
             avg_loss = _run_lbfgs_step(
                 motion_optimizer=motion_optimizer,
-                image_patch_iterator=image_patch_iterator,
+                cached_fft=state.cached_fft,
+                centers_norm=state.centers_norm,
+                base_shifts_cache=state.base_shifts_cache,
                 process_batch_fn=process_batch,
                 lbfgs_patch_subsample=lbfgs_patch_subsample,
                 use_checkpointing=use_checkpointing,
@@ -170,7 +297,9 @@ def estimate_local_motion(
         else:
             avg_loss = _run_standard_step(
                 motion_optimizer=motion_optimizer,
-                image_patch_iterator=image_patch_iterator,
+                cached_fft=state.cached_fft,
+                centers_norm=state.centers_norm,
+                base_shifts_cache=state.base_shifts_cache,
                 process_batch_fn=process_batch,
             )
 
@@ -198,12 +327,11 @@ def estimate_local_motion(
 
 
 def _process_patch_batch(
-    patch_batch: torch.Tensor,
+    fft_batch: torch.Tensor,
     patch_batch_centers: torch.Tensor,
-    circle_mask: torch.Tensor,
+    base_shifts_batch: torch.Tensor,
     b_factor_envelope: torch.Tensor,
     bandpass: torch.Tensor,
-    base_deformation_field: DeformationField,
     new_deformation_field: DeformationField,
     pixel_spacing: float,
     ph: int,
@@ -211,30 +339,30 @@ def _process_patch_batch(
     loss_type: str,
     t: int,
 ) -> torch.Tensor:
-    """Apply mask, FFT, shift-predict, assemble reference, and compute loss.
+    """Shift-predict, filter, assemble reference, and compute loss for a batch.
 
     Parameters
     ----------
-    patch_batch : torch.Tensor
-        (b, t, ph, pw) real-space image patches.
+    fft_batch : torch.Tensor
+        (b, t, ph, pw//2+1) rFFT of masked (and possibly resolution-cropped) patches,
+        precomputed once.
     patch_batch_centers : torch.Tensor
-        (b, t, 3) normalized (t, y, x) coordinates of each patch center.
-    circle_mask : torch.Tensor
-        (ph, pw) real-space circular apodisation mask.
+        (t, b, 3) normalized (t, y, x) coordinates of each patch center.
+    base_shifts_batch : torch.Tensor
+        (t, b, 2) frozen base deformation field shifts in Angstroms, precomputed once
+        and detached.
     b_factor_envelope : torch.Tensor
         (ph, pw//2+1) rFFT-space B-factor envelope.
     bandpass : torch.Tensor
         (ph, pw//2+1) rFFT-space bandpass filter.
-    base_deformation_field : DeformationField
-        Frozen initial deformation field.
     new_deformation_field : DeformationField
         Optimisable deformation field increment.
     pixel_spacing : float
-        Pixel spacing in Angstroms.
+        Pixel spacing in Angstroms (of the, possibly cropped, patches).
     ph : int
-        Patch height in pixels.
+        Patch height in pixels (possibly cropped).
     pw : int
-        Patch width in pixels.
+        Patch width in pixels (possibly cropped).
     loss_type : str
         Loss function name ("mse", "ncc", or "cc").
     t : int
@@ -245,19 +373,24 @@ def _process_patch_batch(
     torch.Tensor
         Scalar loss value.
     """
-    patch_batch_fft = torch.fft.rfftn(patch_batch * circle_mask, dim=(-2, -1))
-
-    shifted_patches, _ = _compute_shifted_patches_and_shifts(
-        initial_deformation_field=base_deformation_field,
-        new_deformation_field=new_deformation_field,
-        patch_batch=patch_batch_fft,
-        patch_batch_centers=patch_batch_centers,
-        pixel_spacing=pixel_spacing,
-        ph=ph,
-        pw=pw,
-        b_factor_envelope=b_factor_envelope,
-        bandpass=bandpass,
+    predicted_shifts = -1 * (
+        new_deformation_field(patch_batch_centers) + base_shifts_batch
     )
+    predicted_shifts = einops.rearrange(predicted_shifts, "b t yx -> t b yx")
+    predicted_shifts_px = predicted_shifts / pixel_spacing
+
+    shifted_patches = fourier_shift_dft_2d(
+        dft=fft_batch,
+        image_shape=(ph, pw),
+        shifts=predicted_shifts_px,
+        rfft=True,
+        fftshifted=False,
+    )  # (b, t, ph, pw//2 + 1)
+
+    if bandpass is not None:
+        shifted_patches = shifted_patches * bandpass
+    if b_factor_envelope is not None:
+        shifted_patches = shifted_patches * b_factor_envelope
 
     total_sum = torch.sum(shifted_patches, dim=1, keepdim=True)
     if t > 1:
@@ -270,9 +403,49 @@ def _process_patch_batch(
     )
 
 
+def _iterate_cached_batches(
+    cached_fft: torch.Tensor,
+    centers_norm: torch.Tensor,
+    base_shifts_cache: torch.Tensor,
+    batch_size: int,
+    randomized: bool = True,
+) -> Iterator[tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Yield mini-batches from precomputed, cached per-patch tensors.
+
+    Parameters
+    ----------
+    cached_fft : torch.Tensor
+        (n_patches, t, ph, pw//2+1) rFFT of masked (and possibly resolution-cropped)
+        patches.
+    centers_norm : torch.Tensor
+        (t, n_patches, 3) normalized (t, y, x) patch center coordinates.
+    base_shifts_cache : torch.Tensor
+        (t, n_patches, 2) frozen base deformation field shifts, detached.
+    batch_size : int
+        Number of patches per mini-batch.
+    randomized : bool
+        Whether to shuffle patch order. Default is True.
+
+    Yields
+    ------
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        (fft_batch, centers_batch, base_shifts_batch) with shapes (b, t, ph, pw//2+1),
+        (t, b, 3), and (t, b, 2) respectively.
+    """
+    n_patches = cached_fft.shape[0]
+    indices = list(range(n_patches))
+    if randomized:
+        random.shuffle(indices)
+    for i in range(0, n_patches, batch_size):
+        idx = indices[i : i + batch_size]
+        yield cached_fft[idx], centers_norm[:, idx], base_shifts_cache[:, idx]
+
+
 def _run_lbfgs_step(
     motion_optimizer: torch.optim.LBFGS,
-    image_patch_iterator: ImagePatchIterator,
+    cached_fft: torch.Tensor,
+    centers_norm: torch.Tensor,
+    base_shifts_cache: torch.Tensor,
     process_batch_fn: Callable,
     lbfgs_patch_subsample: int | None,
     use_checkpointing: bool,
@@ -284,8 +457,12 @@ def _run_lbfgs_step(
     ----------
     motion_optimizer : torch.optim.LBFGS
         The LBFGS optimizer.
-    image_patch_iterator : ImagePatchIterator
-        Iterator that yields (patch_batch, patch_centers) mini-batches.
+    cached_fft : torch.Tensor
+        (n_patches, t, ph, pw//2+1) precomputed rFFT of masked patches.
+    centers_norm : torch.Tensor
+        (t, n_patches, 3) normalized patch center coordinates.
+    base_shifts_cache : torch.Tensor
+        (t, n_patches, 2) frozen base deformation field shifts, detached.
     process_batch_fn : Callable
         Partially-applied ``_process_patch_batch`` with all frozen args bound.
     lbfgs_patch_subsample : int | None
@@ -306,19 +483,24 @@ def _run_lbfgs_step(
         motion_optimizer.zero_grad()
         weighted_loss_sum = None
         n_batches = 0
-        iterator = image_patch_iterator.get_iterator(batch_size=1, randomized=True)
-        for idx, (patch_batch, patch_batch_centers) in enumerate(iterator):
+        iterator = _iterate_cached_batches(
+            cached_fft, centers_norm, base_shifts_cache, batch_size=1, randomized=True
+        )
+        for idx, (fft_batch, centers_batch, base_shifts_batch) in enumerate(iterator):
             if lbfgs_patch_subsample is not None and idx >= lbfgs_patch_subsample:
                 break
             if use_checkpointing:
                 batch_loss = checkpoint.checkpoint(
                     process_batch_fn,
-                    patch_batch,
-                    patch_batch_centers,
+                    fft_batch,
+                    centers_batch,
+                    base_shifts_batch,
                     use_reentrant=False,
                 )
             else:
-                batch_loss = process_batch_fn(patch_batch, patch_batch_centers)
+                batch_loss = process_batch_fn(
+                    fft_batch, centers_batch, base_shifts_batch
+                )
 
             weighted_loss_sum = (
                 batch_loss
@@ -344,7 +526,9 @@ def _run_lbfgs_step(
 
 def _run_standard_step(
     motion_optimizer: torch.optim.Optimizer,
-    image_patch_iterator: ImagePatchIterator,
+    cached_fft: torch.Tensor,
+    centers_norm: torch.Tensor,
+    base_shifts_cache: torch.Tensor,
     process_batch_fn: Callable,
 ) -> float:
     """Execute one gradient-accumulation step for Adam/SGD/RMSprop.
@@ -353,8 +537,12 @@ def _run_standard_step(
     ----------
     motion_optimizer : torch.optim.Optimizer
         The optimizer (Adam, SGD, or RMSprop).
-    image_patch_iterator : ImagePatchIterator
-        Iterator that yields (patch_batch, patch_centers) mini-batches.
+    cached_fft : torch.Tensor
+        (n_patches, t, ph, pw//2+1) precomputed rFFT of masked patches.
+    centers_norm : torch.Tensor
+        (t, n_patches, 3) normalized patch center coordinates.
+    base_shifts_cache : torch.Tensor
+        (t, n_patches, 2) frozen base deformation field shifts, detached.
     process_batch_fn : Callable
         Partially-applied ``_process_patch_batch`` with all frozen args bound.
 
@@ -363,88 +551,22 @@ def _run_standard_step(
     float
         Average per-batch loss for this step.
     """
-    patch_iter = image_patch_iterator.get_iterator(batch_size=8)  # TODO: expose
+    patch_iter = _iterate_cached_batches(
+        cached_fft,
+        centers_norm,
+        base_shifts_cache,
+        batch_size=8,  # TODO: expose
+    )
     total_loss = 0.0
     n_batches = 0
-    for patch_batch, patch_batch_centers in patch_iter:
-        loss = process_batch_fn(patch_batch, patch_batch_centers)
+    for fft_batch, centers_batch, base_shifts_batch in patch_iter:
+        loss = process_batch_fn(fft_batch, centers_batch, base_shifts_batch)
         loss.backward()
         total_loss += loss.item()
         n_batches += 1
     motion_optimizer.step()
     motion_optimizer.zero_grad()
     return total_loss / n_batches if n_batches > 0 else 0.0
-
-
-def _compute_shifted_patches_and_shifts(
-    initial_deformation_field: DeformationField,
-    new_deformation_field: DeformationField,
-    patch_batch: torch.Tensor,
-    patch_batch_centers: torch.Tensor,
-    pixel_spacing: float,
-    ph: int,
-    pw: int,
-    b_factor_envelope: torch.Tensor = None,
-    bandpass: torch.Tensor = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute the forward pass for motion estimation for a batch of patches.
-
-    Parameters
-    ----------
-    initial_deformation_field : DeformationField
-        The deformation field model to predict shifts.
-    new_deformation_field : DeformationField
-        The new deformation field model to predict shifts.
-    patch_batch : torch.Tensor
-        A batch of image patches in Fourier space with shape (b, t, ph, pw).
-    patch_batch_centers : torch.Tensor
-        Normalized control point centers for the batch with shape (b, t, 3).
-    pixel_spacing : float
-        Pixel spacing in Angstroms.
-    ph : int
-        Patch height in pixels.
-    pw : int
-        Patch width in pixels.
-    b_factor_envelope : torch.Tensor | None
-        The B-factor envelope to apply in Fourier space with shape (ph, pw//2 + 1).
-        If None, no envelope is applied.
-    bandpass : torch.Tensor | None
-        The bandpass filter to apply in Fourier space with shape (ph, pw//2 + 1).
-        If None, no bandpass is applied.
-
-    Returns
-    -------
-    tuple[torch.Tensor, torch.Tensor]
-        A tuple containing:
-        - shifted_patches: The shifted patches after applying predicted shifts and
-          filters, with shape (b, t, ph, pw//2 + 1).
-        - predicted_shifts: The predicted shifts from the deformation field,
-          with shape (b, t, 2).
-    """
-    predicted_shifts = -1 * (
-        new_deformation_field(patch_batch_centers)
-        + initial_deformation_field(patch_batch_centers).detach()
-    )
-    predicted_shifts = einops.rearrange(predicted_shifts, "b t yx -> t b yx")
-    predicted_shifts_px = predicted_shifts / pixel_spacing
-
-    # Shift the patches by the predicted shifts
-    shifted_patches = fourier_shift_dft_2d(
-        dft=patch_batch,
-        image_shape=(ph, pw),
-        shifts=predicted_shifts_px,
-        rfft=True,
-        fftshifted=False,
-    )  # (b, t, ph, pw//2 + 1)
-
-    # Apply Fourier filters
-    if bandpass is not None:
-        shifted_patches = shifted_patches * bandpass
-
-    if b_factor_envelope is not None:
-        shifted_patches = shifted_patches * b_factor_envelope
-
-    return shifted_patches, predicted_shifts
 
 
 def _setup_optimizer(

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
@@ -19,7 +19,7 @@ from torch_motion_correction.types import (
     OptimizationConfig,
     PatchSamplingConfig,
 )
-from torch_motion_correction.utils import normalize_image, prepare_patch_filters
+from torch_motion_correction.utils import prepare_patch_filters
 
 
 @dataclass
@@ -64,7 +64,8 @@ def _prepare_patch_state(
     Parameters
     ----------
     image : torch.Tensor
-        (t, H, W) movie, already moved to ``device``. Normalized internally.
+        (t, H, W) movie, already moved to ``device``. Normalized internally, per patch
+        chunk.
     pixel_spacing : float
         Pixel spacing in Angstroms.
     deformation_field_resolution : tuple[int, int, int]
@@ -89,7 +90,13 @@ def _prepare_patch_state(
     patch_shape = patch_sampling.patch_shape
     ph, pw = patch_shape
 
-    image = normalize_image(image)
+    t, h, w = image.shape
+    hl, hu = int(0.25 * h), int(0.75 * h)
+    wl, wu = int(0.25 * w), int(0.75 * w)
+    norm_std, norm_mean = torch.std_mean(image[:, hl:hu, wl:wu], dim=(-3, -2, -1))
+    norm_std = norm_std.to(device)
+    norm_mean = norm_mean.to(device)
+
     image_patch_iterator = patch_sampling.get_patch_iterator(image=image, device=device)
 
     new_deformation_field, base_deformation_field = DeformationField.from_initial_field(
@@ -124,6 +131,8 @@ def _prepare_patch_state(
         batch_size=_PRECOMPUTE_CHUNK_SIZE, randomized=False
     )
     for patch_chunk, centers_chunk in chunk_iter:
+        patch_chunk = patch_chunk.to(device)
+        patch_chunk = (patch_chunk - norm_mean) / norm_std
         masked_chunk = patch_chunk * circle_mask
         if will_crop:
             cropped_chunk, _ = fourier_rescale_2d(

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
@@ -64,8 +64,10 @@ def _prepare_patch_state(
     Parameters
     ----------
     image : torch.Tensor
-        (t, H, W) movie, already moved to ``device``. Normalized internally, per patch
-        chunk.
+        (t, H, W) movie. May reside on a different device than ``device`` (e.g.
+        large super-res movie stored on CPU). Patches are extracted onto the image's
+        own device and moved to ``device`` one chunk at a time. Normalized
+        internally, per patch chunk.
     pixel_spacing : float
         Pixel spacing in Angstroms.
     deformation_field_resolution : tuple[int, int, int]
@@ -189,7 +191,8 @@ def estimate_local_motion(
     ----------
     image: torch.Tensor
         (t, H, W) image to estimate motion from where t is the number of frames,
-        H is the height, and W is the width.
+        H is the height, and W is the width. May reside on a different device than
+        ``device`` (e.g. large super-res movie stored on CPU).
     pixel_spacing: float
         Pixel spacing in Angstroms.
     deformation_field_resolution: tuple[int, int, int]
@@ -231,7 +234,6 @@ def estimate_local_motion(
     optimizer_kwargs = optimization.optimizer_kwargs
 
     device = device if device is not None else image.device
-    image = image.to(device)
     t, _h, _w = image.shape
 
     trajectory_kwargs = trajectory_kwargs if trajectory_kwargs is not None else {}

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
@@ -266,7 +266,7 @@ def _process_patch_batch(
         reference_patches = shifted_patches
 
     return _compute_loss(
-        shifted_patches, reference_patches, ph, pw, loss_type=loss_type
+        shifted_patches, reference_patches, ph, pw, loss_type=loss_type, t=t
     )
 
 
@@ -551,6 +551,7 @@ def _compute_loss(
     ph: int,
     pw: int,
     loss_type: str = "mse",
+    t: int | None = None,
 ) -> torch.Tensor:
     """Compute the loss for a batch of shifted patches and reference patches.
 
@@ -567,42 +568,47 @@ def _compute_loss(
     loss_type : str, optional
         The type of loss to compute. Default is "mse". Other option is
         normalized cross-correlation (ncc).
+    t : int, optional
+        Number of frames. When provided (and > 1) for "ncc"/"cc", real-space reference
+        is derived from the real-space shifted patches as their leave-one-out mean. Only
+        valid when ``reference_patches`` constructed via
+        ``(sum(shifted_patches, dim=1) - shifted_patches) / (t - 1)``. If ``t`` is None,
+        falls back to irfft-ing ``reference_patches`` directly.
     """
     if loss_type == "mse":
         return torch.mean((shifted_patches - reference_patches).abs() ** 2) / (ph * pw)
-    elif loss_type == "ncc":
+    elif loss_type in ("ncc", "cc"):
         # Inputs are in rFFT space with shapes:
         # shifted_patches: (b, t, ph, pw//2 + 1)
         # reference_patches: (b, t, ph, pw//2 + 1)
-        # Convert to real space for NCC computation
         shifted_real = torch.fft.irfftn(shifted_patches, s=(ph, pw), dim=(-2, -1))
-        reference_real = torch.fft.irfftn(reference_patches, s=(ph, pw), dim=(-2, -1))
-        # Compute normalized cross-correlation over spatial dims for each (b, t)
-        eps = 1e-8
-        x = shifted_real  # (b, t, ph, pw)
-        y = reference_real  # (b, t, ph, pw)
-        x_mean = x.mean(dim=(-2, -1), keepdim=True)
-        y_mean = y.mean(dim=(-2, -1), keepdim=True)
-        x_centered = x - x_mean
-        y_centered = y - y_mean
-        numerator = (x_centered * y_centered).sum(dim=(-2, -1))  # (b, t)
-        denom = torch.sqrt(
-            (x_centered.square().sum(dim=(-2, -1)) + eps)
-            * (y_centered.square().sum(dim=(-2, -1)) + eps)
-        )
-        ncc = numerator / denom  # (b, t)
-        return -ncc.mean()
-    elif loss_type == "cc":
-        # Inputs are in rFFT space with shapes:
-        # shifted_patches: (b, t, ph, pw//2 + 1)
-        # reference_patches: (b, t, ph, pw//2 + 1)
-        # Convert to real space for CC computation
-        shifted_real = torch.fft.irfftn(shifted_patches, s=(ph, pw), dim=(-2, -1))
-        reference_real = torch.fft.irfftn(reference_patches, s=(ph, pw), dim=(-2, -1))
+        if t is not None and t > 1:
+            sum_real = shifted_real.sum(dim=1, keepdim=True)
+            reference_real = (sum_real - shifted_real) / (t - 1)
+        else:
+            reference_real = torch.fft.irfftn(
+                reference_patches, s=(ph, pw), dim=(-2, -1)
+            )
 
-        # Compute unnormalized cross-correlation over spatial dims
-        # (b, t, ph, pw) * (b, t, ph, pw) → (b, t)
-        cc = (shifted_real * reference_real).sum(dim=(-2, -1))
-
-        # Optionally: mean over batch and time; negate to make it a loss
-        return -cc.mean()
+        if loss_type == "ncc":
+            # Compute normalized cross-correlation over spatial dims for each (b, t)
+            eps = 1e-8
+            x = shifted_real  # (b, t, ph, pw)
+            y = reference_real  # (b, t, ph, pw)
+            x_mean = x.mean(dim=(-2, -1), keepdim=True)
+            y_mean = y.mean(dim=(-2, -1), keepdim=True)
+            x_centered = x - x_mean
+            y_centered = y - y_mean
+            numerator = (x_centered * y_centered).sum(dim=(-2, -1))  # (b, t)
+            denom = torch.sqrt(
+                (x_centered.square().sum(dim=(-2, -1)) + eps)
+                * (y_centered.square().sum(dim=(-2, -1)) + eps)
+            )
+            ncc = numerator / denom  # (b, t)
+            return -ncc.mean()
+        else:
+            # Compute unnormalized cross-correlation over spatial dims
+            # (b, t, ph, pw) * (b, t, ph, pw) → (b, t)
+            cc = (shifted_real * reference_real).sum(dim=(-2, -1))
+            # Optionally: mean over batch and time; negate to make it a loss
+            return -cc.mean()

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_optimizer.py
@@ -38,6 +38,9 @@ class _PrecomputedPatchState:
     pw: int  # possibly Fourier-cropped
 
 
+_PRECOMPUTE_CHUNK_SIZE = 8  # num patches processed per extract/mask/crop/rfft chunk
+
+
 def _prepare_patch_state(
     image: torch.Tensor,  # (t, H, W)
     pixel_spacing: float,
@@ -48,7 +51,7 @@ def _prepare_patch_state(
     initial_deformation_field: DeformationField | None,
     device: torch.device,
 ) -> _PrecomputedPatchState:
-    """Extract, mask, Fourier-crop, and cache all patches once.
+    """Extract, mask, Fourier-crop, and cache all patches once, in small chunks.
 
     Notes
     -----
@@ -105,29 +108,34 @@ def _prepare_patch_state(
         device=device,
     )
 
-    n_patches = (
-        image_patch_iterator.control_points.shape[1]
-        * image_patch_iterator.control_points.shape[2]
-    )
-    all_patches, all_centers_norm = next(
-        iter(image_patch_iterator.get_iterator(batch_size=n_patches, randomized=False))
-    )  # (n_patches, t, ph, pw), (t, n_patches, 3)
-    masked_patches = all_patches * circle_mask
-
-    # Find maximum resolution in the band-pass filter to re-scale patches
     crop_pixel_spacing = fourier_filter.frequency_range[1] / 2
-    if crop_pixel_spacing > pixel_spacing:
-        cached_patches, new_spacing = fourier_rescale_2d(
-            masked_patches,
-            source_spacing=pixel_spacing,
-            target_spacing=crop_pixel_spacing,
-        )
-        ph_eff, pw_eff = cached_patches.shape[-2:]
-        pixel_spacing_eff = new_spacing[0]
+    will_crop = crop_pixel_spacing > pixel_spacing  # Only if crop would reduce size
+    if will_crop:
+        ph_eff = round(ph * pixel_spacing / crop_pixel_spacing)
+        pw_eff = round(pw * pixel_spacing / crop_pixel_spacing)
+        pixel_spacing_eff = pixel_spacing * (ph / ph_eff)
     else:
-        cached_patches = masked_patches
         ph_eff, pw_eff = ph, pw
         pixel_spacing_eff = pixel_spacing
+
+    fft_chunks = []
+    centers_chunks = []
+    chunk_iter = image_patch_iterator.get_iterator(
+        batch_size=_PRECOMPUTE_CHUNK_SIZE, randomized=False
+    )
+    for patch_chunk, centers_chunk in chunk_iter:
+        masked_chunk = patch_chunk * circle_mask
+        if will_crop:
+            cropped_chunk, _ = fourier_rescale_2d(
+                masked_chunk, target_shape=(ph_eff, pw_eff)
+            )
+        else:
+            cropped_chunk = masked_chunk
+        fft_chunks.append(torch.fft.rfftn(cropped_chunk, dim=(-2, -1)))
+        centers_chunks.append(centers_chunk)
+
+    cached_fft = torch.cat(fft_chunks, dim=0)  # (n_patches, t, ph_eff, pw_eff//2+1)
+    all_centers_norm = torch.cat(centers_chunks, dim=1)  # (t, n_patches, 3)
 
     # Fourier filters, rebuilt at the (possibly cropped) resolution/spacing.
     _, b_factor_envelope, bandpass_filter = prepare_patch_filters(
@@ -138,7 +146,6 @@ def _prepare_patch_state(
         device=device,
     )
 
-    cached_fft = torch.fft.rfftn(cached_patches, dim=(-2, -1))
     with torch.no_grad():
         base_shifts_cache = base_deformation_field(all_centers_norm).detach()
 

--- a/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_xc.py
+++ b/packages/algorithms/torch-motion-correction/src/torch_motion_correction/estimate_motion_xc.py
@@ -2,6 +2,7 @@
 
 import einops
 import torch
+import torch.nn.functional as F
 from scipy.signal import savgol_filter
 from torch_grid_utils.patch_grid import patch_grid_lazy
 
@@ -12,7 +13,7 @@ from torch_motion_correction.types import (
     PatchSamplingConfig,
     XCRefinementConfig,
 )
-from torch_motion_correction.utils import normalize_image, prepare_patch_filters
+from torch_motion_correction.utils import prepare_patch_filters
 
 
 def estimate_global_motion(
@@ -22,13 +23,15 @@ def estimate_global_motion(
     fourier_filter: FourierFilterConfig | None = None,
     device: torch.device | None = None,
     verbose: bool = False,
+    downsample_factor: int = 1,
 ) -> DeformationField:
     """Estimate motion using cross-correlation for the whole image.
 
     Parameters
     ----------
     image: torch.Tensor
-        (t, h, w) array of images to motion correct
+        (t, h, w) array of images to motion correct. May live on a different
+        device than ``device`` (e.g. CPU); frames are transferred lazily.
     pixel_spacing: float
         Pixel spacing in angstroms
     reference_frame: int, optional
@@ -40,6 +43,11 @@ def estimate_global_motion(
         Device for computation
     verbose: bool
         Whether to print progress information. Default is False.
+    downsample_factor: int
+        Integer factor to downsample (average pool) each frame before cross-correlation.
+        The sub-pixel precision lost to downsampling may be acceptable in exchange for
+        large reductions in per-frame compute and memory on very large movies. Default
+        is 1 (no downsampling).
 
     Returns
     -------
@@ -49,13 +57,8 @@ def estimate_global_motion(
     if fourier_filter is None:
         fourier_filter = FourierFilterConfig()
 
-    # b_factor = fourier_filter.b_factor
-    # frequency_range = fourier_filter.frequency_range
-
     if device is None:
         device = image.device
-    else:
-        image = image.to(device)
 
     t, h, w = image.shape
 
@@ -68,22 +71,38 @@ def estimate_global_motion(
             f"Cross-correlation whole image: using frame {reference_frame} as reference"
         )
 
-    # Normalize image
-    image = normalize_image(image)
+    if downsample_factor > 1:
+        h_ds, w_ds = h // downsample_factor, w // downsample_factor
+        working_pixel_spacing = pixel_spacing * downsample_factor
+    else:
+        h_ds, w_ds = h, w
+        working_pixel_spacing = pixel_spacing
 
     mask, b_factor_envelope, bandpass = prepare_patch_filters(
-        shape=(h, w),
-        pixel_spacing=pixel_spacing,
+        shape=(h_ds, w_ds),
+        pixel_spacing=working_pixel_spacing,
         fourier_filter=fourier_filter,
         device=device,
     )
+    combined_filter = bandpass * b_factor_envelope
 
-    # Apply mask, FFT, and filters to all frames at once
-    fft_images = torch.fft.rfftn(image * mask, dim=(-2, -1))
-    filtered_fft = fft_images * bandpass * b_factor_envelope
+    hl, hu = int(0.25 * h_ds), int(0.75 * h_ds)
+    wl, wu = int(0.25 * w_ds), int(0.75 * w_ds)
 
-    # Reference frame
-    reference_fft = filtered_fft[reference_frame]
+    def _prepare_frame_fft(frame_idx: int) -> torch.Tensor:
+        """Downsample, normalize, mask, FFT and filter a single frame."""
+        frame = image[frame_idx].to(device)  # transfer only this one frame
+        if downsample_factor > 1:
+            frame = F.avg_pool2d(frame[None, None], kernel_size=downsample_factor)
+            frame = frame[0, 0]
+
+        frame_std, frame_mean = torch.std_mean(frame[hl:hu, wl:wu])
+        frame = (frame - frame_mean) / frame_std
+
+        frame_fft = torch.fft.rfftn(frame * mask, dim=(-2, -1))
+        return frame_fft * combined_filter
+
+    reference_fft = _prepare_frame_fft(reference_frame)
 
     # Calculate shifts for each frame
     shifts = torch.zeros((t, 2), device=device)  # (y, x) shifts
@@ -93,17 +112,17 @@ def estimate_global_motion(
             continue  # Reference frame has zero shift
 
         # Cross-correlation in frequency domain
-        frame_fft = filtered_fft[frame_idx]
+        frame_fft = _prepare_frame_fft(frame_idx)
         cross_corr_fft = torch.conj(reference_fft) * frame_fft
-        cross_corr = torch.fft.irfftn(cross_corr_fft, s=(h, w))
+        cross_corr = torch.fft.irfftn(cross_corr_fft, s=(h_ds, w_ds))
 
         # Find peak position
         peak_idx = torch.argmax(cross_corr.flatten())
-        peak_y, peak_x = divmod(peak_idx.item(), w)
+        peak_y, peak_x = divmod(peak_idx.item(), w_ds)
 
         # Convert to shifts (handle wraparound)
-        shift_y = peak_y if peak_y <= h // 2 else peak_y - h
-        shift_x = peak_x if peak_x <= w // 2 else peak_x - w
+        shift_y = peak_y if peak_y <= h_ds // 2 else peak_y - h_ds
+        shift_x = peak_x if peak_x <= w_ds // 2 else peak_x - w_ds
 
         shifts[frame_idx] = torch.tensor([shift_y, shift_x], device=device)
 
@@ -115,7 +134,7 @@ def estimate_global_motion(
         )
 
     return DeformationField.from_frame_shifts(
-        shifts=shifts, pixel_spacing=pixel_spacing, device=device
+        shifts=shifts, pixel_spacing=working_pixel_spacing, device=device
     )
 
 
@@ -136,7 +155,8 @@ def estimate_motion_cross_correlation_patches(
     Parameters
     ----------
     image: torch.Tensor
-        (t, h, w) array of images to motion correct
+        (t, h, w) array of images to motion correct. May live on a different device than
+        parameter ``device`` (e.g. CPU). Patches are transferred lazily.
     pixel_spacing: float
         Pixel spacing in angstroms
     patch_sampling: PatchSamplingConfig
@@ -190,16 +210,18 @@ def estimate_motion_cross_correlation_patches(
 
     if device is None:
         device = image.device
-    else:
-        image = image.to(device)
 
-    t, _h, _w = image.shape
+    t, h, w = image.shape
 
     # Use middle frame as reference if not specified
     if reference_frame is None:
         reference_frame = t // 2
 
-    image = normalize_image(image)
+    hl, hu = int(0.25 * h), int(0.75 * h)
+    wl, wu = int(0.25 * w), int(0.75 * w)
+    norm_std, norm_mean = torch.std_mean(image[:, hl:hu, wl:wu])
+    norm_std = norm_std.to(device)
+    norm_mean = norm_mean.to(device)
 
     if verbose:
         if reference_strategy == "middle_frame":
@@ -256,6 +278,7 @@ def estimate_motion_cross_correlation_patches(
         fourier_filter=fourier_filter,
         device=device,
     )
+    combined_filter = bandpass * b_factor_envelope
 
     # Initialize or update raw deformation field tensor
     if initial_deformation_field is None:
@@ -271,6 +294,30 @@ def estimate_motion_cross_correlation_patches(
     # Use local variable for the raw tensor during frame processing
     deformation_field_tensor = raw_field
 
+    def _get_frame_patches(frame_idx: int) -> torch.Tensor:
+        """Extract, transfer to device, and normalize one frame's patches."""
+        patches = lazy_patch_grid[frame_idx]  # (1, gh, gw, 1, ph, pw), lazy device
+        patches = einops.rearrange(patches, "1 gh gw 1 ph pw -> gh gw ph pw")
+        patches = patches.to(device)
+        return (patches - norm_mean) / norm_std
+
+    # For "mean_except_current", precompute the sum of every frame's patches once.
+    total_patches_sum = None
+    if reference_strategy == "mean_except_current":
+        for other_frame_idx in range(t):
+            other_patches = _get_frame_patches(other_frame_idx)
+            if total_patches_sum is None:
+                total_patches_sum = other_patches.clone()
+            else:
+                total_patches_sum += other_patches
+    elif reference_strategy == "middle_frame":
+        ref_patches_middle = _get_frame_patches(reference_frame) * mask
+        ref_patches_fft_middle = (
+            torch.fft.rfftn(ref_patches_middle, dim=(-2, -1)) * combined_filter
+        )
+    else:
+        raise ValueError(f"Unknown reference_strategy: {reference_strategy}")
+
     # Process each frame individually to manage memory
     for frame_idx in range(t):
         if reference_strategy == "middle_frame" and frame_idx == reference_frame:
@@ -279,50 +326,22 @@ def estimate_motion_cross_correlation_patches(
         if verbose:
             print(f"Processing frame {frame_idx}/{t - 1}")
 
-        # Determine reference patches based on strategy
+        frame_patches = _get_frame_patches(frame_idx)
+
         if reference_strategy == "middle_frame":
-            # Use middle frame as reference
-            ref_patches = lazy_patch_grid[reference_frame]  # (1, gh, gw, 1, ph, pw)
-            ref_patches = einops.rearrange(
-                ref_patches, "1 gh gw 1 ph pw -> gh gw ph pw"
+            ref_patches_fft = ref_patches_fft_middle
+        else:  # "mean_except_current"
+            assert total_patches_sum is not None
+            ref_patches = (total_patches_sum - frame_patches) / (t - 1)
+            ref_patches = ref_patches * mask
+            ref_patches_fft = (
+                torch.fft.rfftn(ref_patches, dim=(-2, -1)) * combined_filter
             )
-        elif reference_strategy == "mean_except_current":
-            # Use mean of all frames except current frame (computed
-            # incrementally to save memory)
-            ref_patches = None
-            count = 0
-            for other_frame_idx in range(t):
-                if other_frame_idx != frame_idx:
-                    other_patches = lazy_patch_grid[
-                        other_frame_idx
-                    ]  # (1, gh, gw, 1, ph, pw)
-                    other_patches = einops.rearrange(
-                        other_patches, "1 gh gw 1 ph pw -> gh gw ph pw"
-                    )
-                    if ref_patches is None:
-                        ref_patches = other_patches.clone()
-                    else:
-                        ref_patches += other_patches
-                    count += 1
-            ref_patches = ref_patches / count
-        else:
-            raise ValueError(f"Unknown reference_strategy: {reference_strategy}")
-
-        # Get patches for current frame only
-        frame_patches = lazy_patch_grid[frame_idx]  # (1, gh, gw, 1, ph, pw)
-        frame_patches = einops.rearrange(
-            frame_patches, "1 gh gw 1 ph pw -> gh gw ph pw"
-        )
-
-        # Apply mask and filters to reference patches
-        ref_patches *= mask
-        ref_patches_fft = torch.fft.rfftn(ref_patches, dim=(-2, -1))
-        ref_patches_fft = ref_patches_fft * bandpass * b_factor_envelope
 
         # Apply mask and filters to frame patches
-        frame_patches *= mask
+        frame_patches = frame_patches * mask
         frame_patches_fft = torch.fft.rfftn(frame_patches, dim=(-2, -1))
-        frame_patches_fft = frame_patches_fft * bandpass * b_factor_envelope
+        frame_patches_fft = frame_patches_fft * combined_filter
 
         # Vectorized cross-correlation for all patches at once
         cross_corr_fft = torch.conj(ref_patches_fft) * frame_patches_fft

--- a/packages/algorithms/torch-motion-correction/tests/test_correct_motion.py
+++ b/packages/algorithms/torch-motion-correction/tests/test_correct_motion.py
@@ -539,4 +539,74 @@ class TestCorrectMotionTwoGrids:
         # computation graph works correctly
         # Base grid should NOT have gradients (it's detached in the function)
         # The base grid's shifts are detached, so gradients won't flow to it
+
+
+class TestPixelGridHoisting:
+    """Regression tests for hoisting ``coordinate_grid`` out of the per-frame loop."""
+
+    def test_correct_motion_matches_per_frame_grid(
+        self, sample_image, sample_deformation_field, pixel_spacing
+    ):
+        from torch_grid_utils import coordinate_grid
+
+        from torch_motion_correction.correct_motion import _correct_frame
+
+        field = DeformationField(data=sample_deformation_field)
+        t, h, w = sample_image.shape
+        _, _, gh, gw = field.data.shape
+        normalized_t = torch.linspace(0, 1, steps=t)
+
+        # Reference: recompute the pixel grid independently for every frame.
+        expected = torch.stack(
+            [
+                _correct_frame(
+                    frame=frame,
+                    frame_deformation_grid=field.evaluate_at_t(
+                        t=frame_t, grid_shape=(10 * gh, 10 * gw)
+                    ),
+                    pixel_spacing=pixel_spacing,
+                    pixel_grid=coordinate_grid(image_shape=(h, w), device=frame.device),
+                )
+                for frame, frame_t in zip(sample_image, normalized_t)
+            ],
+            dim=0,
+        )
+
+        actual = correct_motion(
+            image=sample_image,
+            deformation_field=field,
+            pixel_spacing=pixel_spacing,
+            device=torch.device("cpu"),
+        )
+        torch.testing.assert_close(actual, expected)
+
+    def test_correct_motion_slow_matches_per_frame_grid(
+        self, sample_image, sample_deformation_field
+    ):
+        from torch_grid_utils import coordinate_grid
+
+        from torch_motion_correction.correct_motion import _correct_frame_slow
+
+        t, h, w = sample_image.shape
+        normalized_t = torch.linspace(0, 1, steps=t)
+
+        expected = torch.stack(
+            [
+                _correct_frame_slow(
+                    frame=frame,
+                    deformation_grid=sample_deformation_field,
+                    t=frame_t,
+                    pixel_grid=coordinate_grid(image_shape=(h, w), device=frame.device),
+                )
+                for frame, frame_t in zip(sample_image, normalized_t)
+            ],
+            dim=0,
+        )
+
+        actual = correct_motion_slow(
+            image=sample_image,
+            deformation_field=DeformationField(data=sample_deformation_field),
+            device=torch.device("cpu"),
+        )
+        torch.testing.assert_close(actual, expected)
         # even if requires_grad was set to True

--- a/packages/algorithms/torch-motion-correction/tests/test_correct_motion.py
+++ b/packages/algorithms/torch-motion-correction/tests/test_correct_motion.py
@@ -185,19 +185,48 @@ class TestCorrectMotionFast:
     def test_different_devices(
         self, sample_image, sample_single_patch_deformation_field
     ):
-        """Test that device parameter works."""
+        """Test that `device` controls compute location, not output location."""
         if torch.cuda.is_available():
-            corrected = correct_motion_fast(
+            corrected_gpu = correct_motion_fast(
                 image=sample_image,
                 deformation_field=DeformationField(
                     data=sample_single_patch_deformation_field
                 ),
                 device=torch.device("cuda"),
             )
-            assert corrected.device.type == "cuda"
-            assert corrected.shape == sample_image.shape
+            assert corrected_gpu.device.type == sample_image.device.type == "cpu"
+            assert corrected_gpu.shape == sample_image.shape
+
+            corrected_cpu = correct_motion_fast(
+                image=sample_image,
+                deformation_field=DeformationField(
+                    data=sample_single_patch_deformation_field
+                ),
+                device=torch.device("cpu"),
+            )
+            # Streaming through the GPU must give the same result as computing
+            # entirely on CPU.
+            assert torch.allclose(corrected_gpu, corrected_cpu, atol=1e-4)
         else:
             pytest.skip("CUDA not available")
+
+    def test_does_not_mutate_input_deformation_field(
+        self, sample_image, sample_single_patch_deformation_field
+    ):
+        """Applying shifts must not flip the sign of the caller's field in place.
+
+        `deformation_field.to(device)` is a no-op (shares storage) when the
+        field is already on `device`, so an in-place negation of the derived
+        shifts would silently corrupt the caller's `DeformationField.data`.
+        """
+        field = DeformationField(data=sample_single_patch_deformation_field.clone())
+        original_data = field.data.clone()
+        correct_motion_fast(
+            image=sample_image,
+            deformation_field=field,
+            device=torch.device("cpu"),
+        )
+        assert torch.equal(field.data, original_data)
 
     def test_zero_deformation_field(self, sample_image):
         """Test with zero deformation field."""

--- a/packages/algorithms/torch-motion-correction/tests/test_correct_motion.py
+++ b/packages/algorithms/torch-motion-correction/tests/test_correct_motion.py
@@ -117,16 +117,26 @@ class TestCorrectMotion:
     def test_different_devices(
         self, sample_image, sample_deformation_field, pixel_spacing
     ):
-        """Test that device parameter works."""
+        """Test that `device` controls compute location, not output location."""
         if torch.cuda.is_available():
-            corrected = correct_motion(
+            corrected_gpu = correct_motion(
                 image=sample_image,
                 deformation_field=DeformationField(data=sample_deformation_field),
                 pixel_spacing=pixel_spacing,
                 device=torch.device("cuda"),
             )
-            assert corrected.device.type == "cuda"
-            assert corrected.shape == sample_image.shape
+            assert corrected_gpu.device.type == sample_image.device.type == "cpu"
+            assert corrected_gpu.shape == sample_image.shape
+
+            corrected_cpu = correct_motion(
+                image=sample_image,
+                deformation_field=DeformationField(data=sample_deformation_field),
+                pixel_spacing=pixel_spacing,
+                device=torch.device("cpu"),
+            )
+            # Streaming through the GPU must give the same result as computing
+            # entirely on CPU.
+            assert torch.allclose(corrected_gpu, corrected_cpu, atol=1e-4)
         else:
             pytest.skip("CUDA not available")
 

--- a/packages/algorithms/torch-motion-correction/tests/test_estimate_motion.py
+++ b/packages/algorithms/torch-motion-correction/tests/test_estimate_motion.py
@@ -270,6 +270,18 @@ class TestEstimateLocalMotion:
             )
             assert result.shape == (2, sample_image.shape[0], 2, 2)
 
+    def test_lbfgs_optimizer(self, sample_image, pixel_spacing):
+        """Test the LBFGS optimizer path (uses a separate closure/batching path)."""
+        result, _ = estimate_local_motion(
+            image=sample_image,
+            pixel_spacing=pixel_spacing,
+            deformation_field_resolution=(sample_image.shape[0], 2, 2),
+            patch_sampling=PatchSamplingConfig(patch_shape=(32, 32)),
+            optimization=OptimizationConfig(max_iterations=2, optimizer_type="lbfgs"),
+            device=torch.device("cpu"),
+        )
+        assert result.shape == (2, sample_image.shape[0], 2, 2)
+
     def test_different_grid_types(self, sample_image, pixel_spacing):
         """Test different grid types via OptimizationConfig."""
         for grid_type in ["catmull_rom", "bspline"]:
@@ -388,3 +400,79 @@ class TestComputeLossIrfftLinearity:
         assert shifted.grad is not None
         assert torch.isfinite(shifted.grad).all()
         assert shifted.grad.abs().sum() > 0
+
+
+class TestFourierResolutionCropping:
+    """Regression tests for cropping patches to the bandpass's resolution cutoff."""
+
+    def test_crop_applied_by_default_still_converges(self, sample_image, pixel_spacing):
+        """Default FourierFilterConfig (frequency_range=(300, 10)) at
+        pixel_spacing=1.0 triggers cropping (crop spacing 5.0 > 1.0). Optimization
+        should still reduce loss on an image with injected motion.
+        """
+        result, tracker = estimate_local_motion(
+            image=sample_image,
+            pixel_spacing=pixel_spacing,
+            deformation_field_resolution=(sample_image.shape[0], 2, 2),
+            patch_sampling=PatchSamplingConfig(patch_shape=(32, 32)),
+            optimization=OptimizationConfig(
+                max_iterations=15, loss_type="ncc", optimizer_kwargs={"lr": 0.05}
+            ),
+            device=torch.device("cpu"),
+        )
+        assert result.shape == (2, sample_image.shape[0], 2, 2)
+        losses = [cp.loss for cp in tracker.checkpoints]
+        assert losses[-1] < losses[0]
+
+    def test_crop_skipped_when_not_beneficial(self, sample_image, pixel_spacing):
+        """A tight frequency_range whose resolution cutoff is finer than the
+        native pixel spacing must not trigger cropping (crop_pixel_spacing <
+        pixel_spacing), and optimization should still work.
+        """
+        result, _ = estimate_local_motion(
+            image=sample_image,
+            pixel_spacing=pixel_spacing,
+            deformation_field_resolution=(sample_image.shape[0], 2, 2),
+            patch_sampling=PatchSamplingConfig(patch_shape=(32, 32)),
+            fourier_filter=FourierFilterConfig(frequency_range=(300, 1.0)),
+            optimization=OptimizationConfig(max_iterations=2),
+            device=torch.device("cpu"),
+        )
+        assert result.shape == (2, sample_image.shape[0], 2, 2)
+
+    def test_cropped_and_uncropped_give_similar_final_field(
+        self, sample_image, pixel_spacing
+    ):
+        """Sanity check that cropping doesn't change *what* is being optimized:
+        a run with cropping disabled (tight frequency_range) and a run with
+        cropping enabled (default range) should converge to roughly the same
+        deformation field on the same synthetic motion.
+        """
+        torch.manual_seed(0)
+        common_kwargs = {
+            "image": sample_image,
+            "pixel_spacing": pixel_spacing,
+            "deformation_field_resolution": (sample_image.shape[0], 2, 2),
+            "patch_sampling": PatchSamplingConfig(patch_shape=(32, 32)),
+            "optimization": OptimizationConfig(
+                max_iterations=25, loss_type="ncc", optimizer_kwargs={"lr": 0.05}
+            ),
+            "device": torch.device("cpu"),
+        }
+
+        torch.manual_seed(0)
+        result_cropped, _ = estimate_local_motion(
+            fourier_filter=FourierFilterConfig(frequency_range=(300, 10)),
+            **common_kwargs,
+        )
+        torch.manual_seed(0)
+        result_uncropped, _ = estimate_local_motion(
+            fourier_filter=FourierFilterConfig(frequency_range=(300, 1.0)),
+            **common_kwargs,
+        )
+
+        # Both should recover a similar overall shift pattern; loose tolerance
+        # since the two runs operate at different effective resolutions.
+        torch.testing.assert_close(
+            result_cropped.data, result_uncropped.data, atol=0.5, rtol=0.5
+        )

--- a/packages/algorithms/torch-motion-correction/tests/test_estimate_motion.py
+++ b/packages/algorithms/torch-motion-correction/tests/test_estimate_motion.py
@@ -4,7 +4,10 @@ import pytest
 import torch
 
 from torch_motion_correction.deformation_field import DeformationField
-from torch_motion_correction.estimate_motion_optimizer import estimate_local_motion
+from torch_motion_correction.estimate_motion_optimizer import (
+    _compute_loss,
+    estimate_local_motion,
+)
 from torch_motion_correction.estimate_motion_xc import (
     estimate_global_motion,
     estimate_motion_cross_correlation_patches,
@@ -334,3 +337,54 @@ class TestEstimateLocalMotion:
             device=torch.device("cpu"),
         )
         assert isinstance(result, DeformationField)
+
+
+class TestComputeLossIrfftLinearity:
+    """Regression tests for the single-irfft ncc/cc path in ``_compute_loss``."""
+
+    @staticmethod
+    def _make_batch(b, t, ph, pw, seed):
+        torch.manual_seed(seed)
+        shifted = torch.randn(b, t, ph, pw // 2 + 1, dtype=torch.complex64)
+        total_sum = shifted.sum(dim=1, keepdim=True)
+        reference = (total_sum - shifted) / (t - 1)
+        return shifted, reference
+
+    @pytest.mark.parametrize("loss_type", ["ncc", "cc"])
+    def test_fast_path_matches_fallback(self, loss_type):
+        b, t, ph, pw = 4, 6, 32, 32
+        shifted, reference = self._make_batch(b, t, ph, pw, seed=0)
+
+        fast = _compute_loss(shifted, reference, ph, pw, loss_type=loss_type, t=t)
+        fallback = _compute_loss(
+            shifted, reference, ph, pw, loss_type=loss_type, t=None
+        )
+        torch.testing.assert_close(fast, fallback, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize("loss_type", ["ncc", "cc"])
+    def test_single_frame_edge_case(self, loss_type):
+        # t == 1: reference_patches == shifted_patches, both code paths must agree.
+        b, ph, pw = 4, 32, 32
+        torch.manual_seed(1)
+        shifted = torch.randn(b, 1, ph, pw // 2 + 1, dtype=torch.complex64)
+        reference = shifted
+
+        with_t = _compute_loss(shifted, reference, ph, pw, loss_type=loss_type, t=1)
+        without_t = _compute_loss(
+            shifted, reference, ph, pw, loss_type=loss_type, t=None
+        )
+        torch.testing.assert_close(with_t, without_t, atol=1e-5, rtol=1e-5)
+
+    def test_gradients_flow_through_fast_path(self):
+        b, t, ph, pw = 4, 6, 32, 32
+        shifted, _ = self._make_batch(b, t, ph, pw, seed=2)
+        shifted.requires_grad_(True)
+        total_sum = shifted.sum(dim=1, keepdim=True)
+        reference = (total_sum - shifted) / (t - 1)
+
+        loss = _compute_loss(shifted, reference, ph, pw, loss_type="ncc", t=t)
+        loss.backward()
+
+        assert shifted.grad is not None
+        assert torch.isfinite(shifted.grad).all()
+        assert shifted.grad.abs().sum() > 0

--- a/packages/algorithms/torch-motion-correction/tests/test_estimate_motion.py
+++ b/packages/algorithms/torch-motion-correction/tests/test_estimate_motion.py
@@ -221,6 +221,117 @@ class TestEstimateMotionCrossCorrelationPatches:
         assert isinstance(result_25, DeformationField)
         assert isinstance(result_50, DeformationField)
 
+    @pytest.mark.parametrize(
+        "reference_strategy", ["mean_except_current", "middle_frame"]
+    )
+    def test_different_devices(self, sample_image, pixel_spacing, reference_strategy):
+        """Test that a CPU-resident image can be processed on a CUDA device."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        assert sample_image.device.type == "cpu"
+        result, patch_positions = estimate_motion_cross_correlation_patches(
+            image=sample_image,
+            pixel_spacing=pixel_spacing,
+            patch_sampling=PatchSamplingConfig(patch_shape=(32, 32)),
+            reference_strategy=reference_strategy,
+            device=torch.device("cuda"),
+        )
+        assert result.data.device.type == "cuda"
+        assert patch_positions is not None
+        assert sample_image.device.type == "cpu"
+
+    def test_mean_except_current_matches_naive_leave_one_out(
+        self, sample_image, pixel_spacing
+    ):
+        """The O(t) precomputed-sum reference must match a naive O(t^2) average.
+
+        Guards the algebraic refactor that derives the leave-one-out reference
+        via `(total - current) / (t - 1)` instead of re-summing the other
+        `t - 1` frames' patches for every frame: computes the naive
+        leave-one-out average directly (independent re-implementation) and
+        compares its cross-correlation peak shifts against the function's
+        output.
+        """
+        import einops
+        from torch_grid_utils.patch_grid import patch_grid_lazy
+
+        from torch_motion_correction.estimate_motion_xc import (
+            _apply_sub_pixel_refinement,
+        )
+        from torch_motion_correction.utils import prepare_patch_filters
+
+        patch_sampling = PatchSamplingConfig(patch_shape=(32, 32))
+        refinement = XCRefinementConfig(
+            temporal_smoothing=False, outlier_rejection=False
+        )
+        fourier_filter = FourierFilterConfig()
+
+        result, _ = estimate_motion_cross_correlation_patches(
+            image=sample_image,
+            pixel_spacing=pixel_spacing,
+            patch_sampling=patch_sampling,
+            reference_strategy="mean_except_current",
+            refinement=refinement,
+            fourier_filter=fourier_filter,
+            device=torch.device("cpu"),
+        )
+
+        # Independent naive re-implementation: re-sum the other t - 1 frames'
+        # patches for every frame instead of using the precomputed total.
+        t, h, w = sample_image.shape
+        ph, pw = patch_sampling.patch_shape
+        hl, hu = int(0.25 * h), int(0.75 * h)
+        wl, wu = int(0.25 * w), int(0.75 * w)
+        norm_std, norm_mean = torch.std_mean(sample_image[:, hl:hu, wl:wu])
+
+        lazy_patch_grid, data_patch_positions = patch_grid_lazy(
+            images=sample_image,
+            patch_shape=(1, ph, pw),
+            patch_step=(1, *patch_sampling.patch_step),
+            distribute_patches=patch_sampling.distribute_patches,
+        )
+        gh, gw = data_patch_positions.shape[1:3]
+        mask, b_factor_envelope, bandpass = prepare_patch_filters(
+            shape=(ph, pw),
+            pixel_spacing=pixel_spacing,
+            fourier_filter=fourier_filter,
+            device=torch.device("cpu"),
+        )
+        combined_filter = bandpass * b_factor_envelope
+
+        def get_patches(idx: int) -> torch.Tensor:
+            patches = lazy_patch_grid[idx]
+            patches = einops.rearrange(patches, "1 gh gw 1 ph pw -> gh gw ph pw")
+            return (patches - norm_mean) / norm_std
+
+        expected_field = torch.zeros((2, t, gh, gw))
+        for frame_idx in range(t):
+            frame_patches = get_patches(frame_idx)
+            others = [get_patches(i) for i in range(t) if i != frame_idx]
+            ref_patches = torch.stack(others, dim=0).sum(dim=0) / (t - 1)
+
+            ref_fft = torch.fft.rfftn(ref_patches * mask, dim=(-2, -1))
+            ref_fft = ref_fft * combined_filter
+            frame_fft = torch.fft.rfftn(frame_patches * mask, dim=(-2, -1))
+            frame_fft = frame_fft * combined_filter
+
+            cross_corr = torch.fft.irfftn(
+                torch.conj(ref_fft) * frame_fft, s=(ph, pw)
+            )
+            cross_corr_flat = cross_corr.view(gh * gw, ph * pw)
+            peak_indices = torch.argmax(cross_corr_flat, dim=1)
+            peak_y, peak_x = _apply_sub_pixel_refinement(
+                cross_corr_flat, peak_indices, ph, pw
+            )
+            shift_y = torch.where(peak_y <= ph // 2, peak_y, peak_y - ph)
+            shift_x = torch.where(peak_x <= pw // 2, peak_x, peak_x - pw)
+            expected_field[0, frame_idx] = shift_y.view(gh, gw) * pixel_spacing
+            expected_field[1, frame_idx] = shift_x.view(gh, gw) * pixel_spacing
+
+        expected_field = expected_field - torch.mean(expected_field)
+        assert torch.allclose(result.data, expected_field, atol=1e-4)
+
 
 class TestEstimateLocalMotion:
     """Tests for estimate_local_motion function."""

--- a/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/dose_weight.py
+++ b/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/dose_weight.py
@@ -365,6 +365,140 @@ def dose_weight_movie_memory_efficient_2d(
     return result
 
 
+def dose_weight_normalization_grid(
+    image_shape: tuple[int, int],
+    pixel_size: float,
+    n_frames: int,
+    pre_exposure: float = 0.0,
+    dose_per_frame: float = 1.0,
+    voltage: float = 300.0,
+    crit_exposure_bfactor: int | float = -1,
+    rfft: bool = True,
+    fftshift: bool = False,
+    a: float = 0.245,
+    b: float = -1.665,
+    c: float = 2.81,
+    device: torch.device | None = None,
+    chunk_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Precompute the per-frequency critical exposure and normalization grids.
+
+    Parameters
+    ----------
+    image_shape : tuple[int, int]
+        The shape of the real space images (h, w).
+    pixel_size : float
+        The pixel size of the images, in Angstroms.
+    n_frames : int
+        The total number of frames in the movie.
+    pre_exposure : float, optional
+        The pre-exposure before the first frame, in e-/A^2. Default is 0.0.
+    dose_per_frame : float, optional
+        The dose per frame, in e-/A^2. Default is 1.0.
+    voltage : float, optional
+        The acceleration voltage in kV. Affects damage correction for 100kV and 200kV.
+        Default is 300.0.
+    crit_exposure_bfactor : int | float, optional
+        The B factor for dose weighting based on critical exposure. If -1,
+        then use Grant and Grigorieff (2015) values. Default is -1.
+    rfft : bool, optional
+        Whether the grid should match a real FFT. Default is True.
+    fftshift : bool, optional
+        Whether the grid should be fftshifted. Default is False.
+    a : float, optional
+        The a parameter for the critical exposure formula. Default is 0.245.
+    b : float, optional
+        The b parameter for the critical exposure formula. Default is -1.665.
+    c : float, optional
+        The c parameter for the critical exposure formula. Default is 2.81.
+    device : torch.device | None, optional
+        The device to compute the grids on. Default is None.
+    chunk_size : int, optional
+        Number of frames' doses to accumulate at a time while summing
+        squared weights across all `n_frames`. Default is 16.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor]
+        `(Ne, normalization)`, each shaped like the frequency grid for
+        `image_shape` (i.e. `(h, w // 2 + 1)` for `rfft=True`). `Ne` is the
+        critical exposure grid; `normalization` is the sqrt of the summed
+        squared weights across all `n_frames`, to be divided into each
+        frame's weight.
+    """
+    frame_indices = torch.arange(n_frames, dtype=torch.float32, device=device)
+    doses = pre_exposure + dose_per_frame * (frame_indices + 1)
+
+    # Apply voltage-dependent damage corrections (follows RELION)
+    if abs(voltage - 200) <= 2:
+        doses = doses / 0.8
+    elif abs(voltage - 100) <= 2:
+        doses = doses / 0.64
+
+    fft_freq_px = fftfreq_grid(
+        image_shape=image_shape,
+        rfft=rfft,
+        fftshift=fftshift,
+        norm=True,
+        device=device,
+    )
+    fft_freq_px /= pixel_size  # Convert to Angstrom^-1
+
+    if crit_exposure_bfactor == -1:
+        Ne = critical_exposure(fft_freq=fft_freq_px, a=a, b=b, c=c)
+    elif crit_exposure_bfactor >= 0:
+        Ne = critical_exposure_bfactor(
+            fft_freq=fft_freq_px, bfactor=crit_exposure_bfactor
+        )
+    else:
+        raise ValueError("B-factor must be positive or -1.")
+
+    # Apply factor of 2 from Eq. 5 (factoring out 0.5)
+    eps = 1e-10
+    Ne = (Ne * 2).clamp(min=eps)
+
+    sum_weight_sq = torch.zeros_like(Ne)
+    for start_idx in range(0, n_frames, chunk_size):
+        end_idx = min(start_idx + chunk_size, n_frames)
+        chunk_doses = doses[start_idx:end_idx]
+        weights = torch.exp(-chunk_doses[:, None, None] / Ne[None])
+        sum_weight_sq += (weights**2).sum(dim=0)
+
+    normalization = torch.sqrt(sum_weight_sq.clamp(min=eps))
+    return Ne, normalization
+
+
+def dose_weight_frame_chunk(
+    chunk_dft: torch.Tensor,
+    frame_start_idx: int,
+    Ne: torch.Tensor,
+    normalization: torch.Tensor,
+    pre_exposure: float = 0.0,
+    dose_per_frame: float = 1.0,
+    voltage: float = 300.0,
+    in_place: bool = False,
+) -> torch.Tensor:
+    """Dose weight one contiguous chunk of a movie's frames' Fourier transforms."""
+    n_chunk = chunk_dft.shape[0]
+    device = chunk_dft.device
+    frame_indices = torch.arange(
+        frame_start_idx, frame_start_idx + n_chunk, dtype=torch.float32, device=device
+    )
+    doses = pre_exposure + dose_per_frame * (frame_indices + 1)
+
+    # Apply voltage-dependent damage corrections (follows RELION)
+    if abs(voltage - 200) <= 2:
+        doses = doses / 0.8
+    elif abs(voltage - 100) <= 2:
+        doses = doses / 0.64
+
+    weights = torch.exp(-doses[:, None, None] / Ne[None]) / normalization[None]
+    if in_place:
+        chunk_dft *= weights
+        return chunk_dft
+    return chunk_dft * weights
+
+
 def dose_weight_movie(
     movie_dft: torch.Tensor,
     image_shape: tuple[int, int],

--- a/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/dose_weight.py
+++ b/packages/primitives/torch-fourier-filter/src/torch_fourier_filter/dose_weight.py
@@ -71,6 +71,80 @@ def critical_exposure_bfactor(fft_freq: torch.Tensor, bfactor: float) -> torch.T
     return Ne
 
 
+def _critical_exposure_grid(
+    image_shape: tuple[int, int],
+    pixel_size: float,
+    crit_exposure_bfactor: int | float = -1,
+    rfft: bool = True,
+    fftshift: bool = False,
+    a: float = 0.245,
+    b: float = -1.665,
+    c: float = 2.81,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Per-frequency critical exposure Ne(k), unscaled (no Eq. 5 factor of 2)."""
+    fft_freq_px = fftfreq_grid(
+        image_shape=image_shape,
+        rfft=rfft,
+        fftshift=fftshift,
+        norm=True,
+        device=device,
+    )
+    fft_freq_px = fft_freq_px / pixel_size  # Convert to Angstrom^-1
+
+    if crit_exposure_bfactor == -1:
+        return critical_exposure(fft_freq=fft_freq_px, a=a, b=b, c=c)
+    elif crit_exposure_bfactor >= 0:
+        return critical_exposure_bfactor(
+            fft_freq=fft_freq_px, bfactor=crit_exposure_bfactor
+        )
+    raise ValueError("B-factor must be positive or -1.")
+
+
+def _apply_voltage_correction(dose: torch.Tensor, voltage: float) -> torch.Tensor:
+    """Apply voltage-dependent damage correction, consistent with RELION."""
+    if abs(voltage - 200) <= 2:
+        return dose / 0.8
+    elif abs(voltage - 100) <= 2:
+        return dose / 0.64
+    return dose
+
+
+def _validate_and_reshape_dose(
+    dose: torch.Tensor | float, image_dft: torch.Tensor
+) -> torch.Tensor | float:
+    """Check a per-batch-element dose tensor matches image_dft's batch shape."""
+    if isinstance(dose, torch.Tensor) and dose.numel() > 1 and image_dft.ndim > 2:
+        image_batch_shape = image_dft.shape[:-2]
+        dose_shape = dose.shape
+        if dose_shape != image_batch_shape:
+            raise ValueError(
+                f"dose tensor shape {dose_shape} "
+                f"does not match image batch dimensions {image_batch_shape}"
+            )
+        dose = einops.rearrange(dose, "... -> ... 1 1")
+    return dose
+
+
+def _dose_weights(dose: torch.Tensor, Ne: torch.Tensor) -> torch.Tensor:
+    """Per-frequency, per-frame weight from Grant & Grigorieff (2015) Eq. 5."""
+    return torch.exp(-dose / Ne)
+
+
+def _frame_doses(
+    n_frames: int,
+    pre_exposure: float,
+    dose_per_frame: float,
+    start_idx: int = 0,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Cumulative dose after each frame in [start_idx, start_idx + n_frames)."""
+    frame_indices = torch.arange(
+        start_idx, start_idx + n_frames, dtype=torch.float32, device=device
+    )
+    return pre_exposure + dose_per_frame * (frame_indices + 1)
+
+
 def dose_weight_2d(
     image_dft: torch.Tensor,  # shape (..., h, w)
     image_shape: tuple[int, int],  # shape (h, w)
@@ -128,19 +202,7 @@ def dose_weight_2d(
     torch.Tensor
         The dose-weighted movie frames with the same shape as input.
     """
-    # If dose is a tensor with more than 1 value,
-    # check it matches the ... batch dimensions in the image.
-    if isinstance(dose, torch.Tensor) and dose.numel() > 1 and image_dft.ndim > 2:
-        # image_dft shape: (..., h, w)
-        image_batch_shape = image_dft.shape[:-2]
-        dose_shape = dose.shape
-        if dose_shape != image_batch_shape:
-            raise ValueError(
-                f"dose tensor shape {dose_shape} "
-                f"does not match image batch dimensions {image_batch_shape}"
-            )
-        else:
-            dose = einops.rearrange(dose, "... -> ... 1 1")
+    dose = _validate_and_reshape_dose(dose, image_dft)
 
     # Determine device
     if device is None:
@@ -149,45 +211,30 @@ def dose_weight_2d(
     # Move movie_dft to specified device if needed
     image_dft = image_dft.to(device)
 
-    # Apply voltage-dependent damage corrections (follows RELION)
-    if abs(voltage - 200) <= 2:
-        dose /= 0.8
-    elif abs(voltage - 100) <= 2:
-        dose /= 0.64
+    dose = _apply_voltage_correction(dose, voltage)
 
-    # Get frequency grid
-    fft_freq_px = fftfreq_grid(
-        image_shape=image_shape,
-        rfft=rfft,
-        fftshift=fftshift,
-        norm=True,
-        device=device,
-    )
-    fft_freq_px /= pixel_size  # Convert to Angstrom^-1
-
-    # Calculate critical exposure for each frequency
-    if crit_exposure_bfactor == -1:
-        Ne = critical_exposure(fft_freq=fft_freq_px, a=a, b=b, c=c)
-    elif crit_exposure_bfactor >= 0:
-        Ne = critical_exposure_bfactor(
-            fft_freq=fft_freq_px, bfactor=crit_exposure_bfactor
-        )
-    else:
-        raise ValueError("B-factor must be positive or -1.")
-
-    # Apply factor of 2 from Eq. 5 (factoring out 0.5)
-    Ne = Ne * 2
-
-    # Add small epsilon to prevent division by zero
     eps = 1e-10
-    Ne = Ne.clamp(min=eps)
+    Ne = (
+        _critical_exposure_grid(
+            image_shape=image_shape,
+            pixel_size=pixel_size,
+            crit_exposure_bfactor=crit_exposure_bfactor,
+            rfft=rfft,
+            fftshift=fftshift,
+            a=a,
+            b=b,
+            c=c,
+            device=device,
+        )
+        * 2  # Apply factor of 2 from Eq. 5 (factoring out 0.5)
+    ).clamp(min=eps)
 
     # Calculate weights for each frame at each frequency
     # Reshape for broadcasting: dose (..., 1, 1) and Ne (1, h, w)
     # Expand Ne to match the number of leading dimensions in dose/image_dft
     n_leading = len(image_dft.shape) - 2  # number of ... dims
     Ne_expanded = einops.rearrange(Ne, "h w -> " + " ".join(["1"] * n_leading) + " h w")
-    weights = torch.exp(-dose / Ne_expanded)  # Shape: (..., h, w)
+    weights = _dose_weights(dose, Ne_expanded)  # Shape: (..., h, w)
 
     # Apply weights to each image
     weighted_images = image_dft * weights
@@ -264,19 +311,7 @@ def dose_weight_movie_memory_efficient_2d(
     torch.Tensor
         The dose-weighted movie frames with the same shape as input.
     """
-    # If dose is a tensor with more than 1 value,
-    # check it matches the ... batch dimensions in the image.
-    if isinstance(dose, torch.Tensor) and dose.numel() > 1 and image_dft.ndim > 2:
-        # image_dft shape: (..., h, w)
-        image_batch_shape = image_dft.shape[:-2]
-        dose_shape = dose.shape
-        if dose_shape != image_batch_shape:
-            raise ValueError(
-                f"dose tensor shape {dose_shape} "
-                f"does not match image batch dimensions {image_batch_shape}"
-            )
-        else:
-            dose = einops.rearrange(dose, "... -> ... 1 1")
+    dose = _validate_and_reshape_dose(dose, image_dft)
 
     # Determine device
     if device is None:
@@ -285,40 +320,26 @@ def dose_weight_movie_memory_efficient_2d(
     # Move image_dft to specified device if needed
     image_dft = image_dft.to(device)
 
-    # Apply voltage-dependent damage corrections (follows RELION)
-    if abs(voltage - 200) <= 2:
-        dose /= 0.8
-    elif abs(voltage - 100) <= 2:
-        dose /= 0.64
+    dose = _apply_voltage_correction(dose, voltage)
 
     n_frames = image_dft.shape[0]
 
-    # Get frequency grid
-    fft_freq_px = fftfreq_grid(
-        image_shape=image_shape,
-        rfft=rfft,
-        fftshift=fftshift,
-        norm=True,
-        device=device,
-    )
-    fft_freq_px /= pixel_size  # Convert to Angstrom^-1
-
-    # Calculate critical exposure for each frequency
-    if crit_exposure_bfactor == -1:
-        Ne = critical_exposure(fft_freq=fft_freq_px, a=a, b=b, c=c)
-    elif crit_exposure_bfactor >= 0:
-        Ne = critical_exposure_bfactor(
-            fft_freq=fft_freq_px, bfactor=crit_exposure_bfactor
-        )
-    else:
-        raise ValueError("B-factor must be positive or -1.")
-
-    # Apply factor of 2 from Eq. 5 (factoring out 0.5)
-    Ne = Ne * 2
-
-    # Add small epsilon to prevent division by zero
     eps = 1e-10
-    Ne = Ne.clamp(min=eps)
+    Ne = (
+        _critical_exposure_grid(
+            image_shape=image_shape,
+            pixel_size=pixel_size,
+            crit_exposure_bfactor=crit_exposure_bfactor,
+            rfft=rfft,
+            fftshift=fftshift,
+            a=a,
+            b=b,
+            c=c,
+            device=device,
+        )
+        * 2  # Apply factor of 2 from Eq. 5 (factoring out 0.5)
+    ).clamp(min=eps)
+    Ne_expanded = einops.rearrange(Ne, "h w -> 1 h w")
 
     # FIRST PASS: Compute normalization factors by accumulating weight sums
     sum_weight_sq = torch.zeros_like(Ne)
@@ -328,8 +349,7 @@ def dose_weight_movie_memory_efficient_2d(
         chunk_doses = dose[start_idx:end_idx]
 
         # Calculate weights for this chunk
-        Ne_expanded = einops.rearrange(Ne, "h w -> 1 h w")
-        weights = torch.exp(-chunk_doses / Ne_expanded)  # (chunk_size, h, w)
+        weights = _dose_weights(chunk_doses, Ne_expanded)  # (chunk_size, h, w)
 
         # Accumulate sum of squared weights
         sum_weight_sq += einops.reduce(weights**2, "... h w -> h w", "sum")
@@ -339,6 +359,7 @@ def dose_weight_movie_memory_efficient_2d(
 
     # Compute normalization factor
     sum_weight_sq = torch.sqrt(sum_weight_sq.clamp(min=eps))
+    sum_weight_sq_expanded = einops.rearrange(sum_weight_sq, "h w -> 1 h w")
 
     # SECOND PASS: Apply weighting and normalization in chunks
     result = torch.zeros_like(image_dft)
@@ -349,14 +370,10 @@ def dose_weight_movie_memory_efficient_2d(
         chunk_movie = image_dft[start_idx:end_idx]
 
         # Calculate weights for this chunk
-        Ne_expanded = einops.rearrange(Ne, "h w -> 1 h w")
-        weights = torch.exp(-chunk_doses / Ne_expanded)  # (chunk_size, h, w)
+        weights = _dose_weights(chunk_doses, Ne_expanded)  # (chunk_size, h, w)
 
-        # Apply weights to chunk
+        # Apply weights to chunk and normalize by sum of squared weights
         weighted_chunk = chunk_movie * weights
-
-        # Normalize by sum of squared weights
-        sum_weight_sq_expanded = einops.rearrange(sum_weight_sq, "h w -> 1 h w")
         normalized_chunk = weighted_chunk / sum_weight_sq_expanded
 
         # Store result
@@ -426,42 +443,30 @@ def dose_weight_normalization_grid(
         squared weights across all `n_frames`, to be divided into each
         frame's weight.
     """
-    frame_indices = torch.arange(n_frames, dtype=torch.float32, device=device)
-    doses = pre_exposure + dose_per_frame * (frame_indices + 1)
+    doses = _frame_doses(n_frames, pre_exposure, dose_per_frame, device=device)
+    doses = _apply_voltage_correction(doses, voltage)
 
-    # Apply voltage-dependent damage corrections (follows RELION)
-    if abs(voltage - 200) <= 2:
-        doses = doses / 0.8
-    elif abs(voltage - 100) <= 2:
-        doses = doses / 0.64
-
-    fft_freq_px = fftfreq_grid(
-        image_shape=image_shape,
-        rfft=rfft,
-        fftshift=fftshift,
-        norm=True,
-        device=device,
-    )
-    fft_freq_px /= pixel_size  # Convert to Angstrom^-1
-
-    if crit_exposure_bfactor == -1:
-        Ne = critical_exposure(fft_freq=fft_freq_px, a=a, b=b, c=c)
-    elif crit_exposure_bfactor >= 0:
-        Ne = critical_exposure_bfactor(
-            fft_freq=fft_freq_px, bfactor=crit_exposure_bfactor
-        )
-    else:
-        raise ValueError("B-factor must be positive or -1.")
-
-    # Apply factor of 2 from Eq. 5 (factoring out 0.5)
     eps = 1e-10
-    Ne = (Ne * 2).clamp(min=eps)
+    Ne = (
+        _critical_exposure_grid(
+            image_shape=image_shape,
+            pixel_size=pixel_size,
+            crit_exposure_bfactor=crit_exposure_bfactor,
+            rfft=rfft,
+            fftshift=fftshift,
+            a=a,
+            b=b,
+            c=c,
+            device=device,
+        )
+        * 2  # Apply factor of 2 from Eq. 5 (factoring out 0.5)
+    ).clamp(min=eps)
 
     sum_weight_sq = torch.zeros_like(Ne)
     for start_idx in range(0, n_frames, chunk_size):
         end_idx = min(start_idx + chunk_size, n_frames)
         chunk_doses = doses[start_idx:end_idx]
-        weights = torch.exp(-chunk_doses[:, None, None] / Ne[None])
+        weights = _dose_weights(chunk_doses[:, None, None], Ne[None])
         sum_weight_sq += (weights**2).sum(dim=0)
 
     normalization = torch.sqrt(sum_weight_sq.clamp(min=eps))
@@ -481,18 +486,12 @@ def dose_weight_frame_chunk(
     """Dose weight one contiguous chunk of a movie's frames' Fourier transforms."""
     n_chunk = chunk_dft.shape[0]
     device = chunk_dft.device
-    frame_indices = torch.arange(
-        frame_start_idx, frame_start_idx + n_chunk, dtype=torch.float32, device=device
+    doses = _frame_doses(
+        n_chunk, pre_exposure, dose_per_frame, start_idx=frame_start_idx, device=device
     )
-    doses = pre_exposure + dose_per_frame * (frame_indices + 1)
+    doses = _apply_voltage_correction(doses, voltage)
 
-    # Apply voltage-dependent damage corrections (follows RELION)
-    if abs(voltage - 200) <= 2:
-        doses = doses / 0.8
-    elif abs(voltage - 100) <= 2:
-        doses = doses / 0.64
-
-    weights = torch.exp(-doses[:, None, None] / Ne[None]) / normalization[None]
+    weights = _dose_weights(doses[:, None, None], Ne[None]) / normalization[None]
     if in_place:
         chunk_dft *= weights
         return chunk_dft
@@ -579,8 +578,9 @@ def dose_weight_movie(
     # Move movie_dft to specified device if needed
     movie_dft = movie_dft.to(device)
     # Calculate doses for each frame (dose AFTER each frame)
-    frame_indices = torch.arange(movie_dft.shape[0], dtype=torch.float32, device=device)
-    doses = pre_exposure + dose_per_frame * (frame_indices + 1)
+    doses = _frame_doses(
+        movie_dft.shape[0], pre_exposure, dose_per_frame, device=device
+    )
 
     if memory_efficient:
         # Use memory-efficient chunked processing
@@ -667,29 +667,18 @@ def cumulative_dose_filter_3d(
     torch.Tensor
         The dose weighting filter.
     """
-    # Get the frequency grid for 1 frame
-    fft_freq_px = fftfreq_grid(
+    eps = 1e-10
+    Ne = _critical_exposure_grid(
         image_shape=volume_shape,
+        pixel_size=pixel_size,
+        crit_exposure_bfactor=crit_exposure_bfactor,
         rfft=rfft,
         fftshift=fftshift,
-        norm=True,
+        a=a,
+        b=b,
+        c=c,
         device=device,
-    )
-    fft_freq_px /= pixel_size  # Convert to Angstrom^-1
-
-    # Get the critical exposure for each frequency
-    if crit_exposure_bfactor == -1:
-        Ne = critical_exposure(fft_freq=fft_freq_px, a=a, b=b, c=c)
-    elif crit_exposure_bfactor >= 0:
-        Ne = critical_exposure_bfactor(
-            fft_freq=fft_freq_px, bfactor=crit_exposure_bfactor
-        )
-    else:
-        raise ValueError("B-factor must be positive or -1.")
-
-    # Add small epsilon to prevent division by zero
-    eps = 1e-10
-    Ne = Ne.clamp(min=eps)
+    ).clamp(min=eps)
 
     return (
         2

--- a/packages/primitives/torch-fourier-filter/tests/test_dose_weight.py
+++ b/packages/primitives/torch-fourier-filter/tests/test_dose_weight.py
@@ -4,7 +4,9 @@ from torch_fourier_filter.dose_weight import (
     critical_exposure,
     critical_exposure_bfactor,
     cumulative_dose_filter_3d,
+    dose_weight_frame_chunk,
     dose_weight_movie,
+    dose_weight_normalization_grid,
 )
 
 
@@ -170,6 +172,99 @@ def test_dose_weight_movie():
         assert "B-factor must be positive" in str(
             e
         ), "Wrong error message for B-factor check"
+
+
+def test_dose_weight_frame_chunk_matches_dose_weight_movie():
+    """Streaming per-chunk dose weighting must match the whole-movie reference.
+
+    `dose_weight_normalization_grid` + `dose_weight_frame_chunk` never see
+    more than `chunk_size` frames of movie data at once, unlike
+    `dose_weight_movie`, which requires the full `movie_dft` up front. They
+    should nonetheless be numerically identical.
+    """
+    n_frames = 11
+    image_shape = (16, 16)
+    pixel_size = 1.5
+    pre_exposure = 0.3
+    dose_per_frame = 1.5
+    voltage = 200.0
+    chunk_size = 4
+
+    torch.manual_seed(0)
+    real_frames = torch.rand((n_frames, *image_shape))
+    movie_dft = torch.fft.rfft2(real_frames)
+
+    expected = dose_weight_movie(
+        movie_dft=movie_dft.clone(),
+        image_shape=image_shape,
+        pixel_size=pixel_size,
+        pre_exposure=pre_exposure,
+        dose_per_frame=dose_per_frame,
+        voltage=voltage,
+        crit_exposure_bfactor=-1,
+        rfft=True,
+        fftshift=False,
+        memory_efficient=True,
+        chunk_size=chunk_size,
+    )
+
+    Ne, normalization = dose_weight_normalization_grid(
+        image_shape=image_shape,
+        pixel_size=pixel_size,
+        n_frames=n_frames,
+        pre_exposure=pre_exposure,
+        dose_per_frame=dose_per_frame,
+        voltage=voltage,
+        crit_exposure_bfactor=-1,
+        rfft=True,
+        fftshift=False,
+    )
+
+    actual = torch.zeros_like(movie_dft)
+    for start_idx in range(0, n_frames, chunk_size):
+        end_idx = min(start_idx + chunk_size, n_frames)
+        actual[start_idx:end_idx] = dose_weight_frame_chunk(
+            chunk_dft=movie_dft[start_idx:end_idx],
+            frame_start_idx=start_idx,
+            Ne=Ne,
+            normalization=normalization,
+            pre_exposure=pre_exposure,
+            dose_per_frame=dose_per_frame,
+            voltage=voltage,
+        )
+
+    assert torch.allclose(actual, expected, atol=1e-5)
+
+
+def test_dose_weight_frame_chunk_in_place():
+    n_frames = 5
+    image_shape = (8, 8)
+    pixel_size = 1.0
+
+    torch.manual_seed(1)
+    movie_dft = torch.fft.rfft2(torch.rand((n_frames, *image_shape)))
+    Ne, normalization = dose_weight_normalization_grid(
+        image_shape=image_shape,
+        pixel_size=pixel_size,
+        n_frames=n_frames,
+    )
+
+    out_of_place = dose_weight_frame_chunk(
+        chunk_dft=movie_dft.clone(),
+        frame_start_idx=0,
+        Ne=Ne,
+        normalization=normalization,
+    )
+    chunk = movie_dft.clone()
+    result = dose_weight_frame_chunk(
+        chunk_dft=chunk,
+        frame_start_idx=0,
+        Ne=Ne,
+        normalization=normalization,
+        in_place=True,
+    )
+    assert result is chunk
+    assert torch.allclose(result, out_of_place)
 
 
 def test_cumulative_dose_filter_3d():


### PR DESCRIPTION
Updates across the frontend and backend of `torch-motion-correction` to improve runtime performance, decrease GPU memory overhead, and support CPU-resident storage of large super-resolution movies. Also includes memory efficiency updates to `torch-fourier-filter` updates for movie doseweighting again for large movies.

- Functions `correct_motion`, `correct_motion_fast`, and the `estimate_global_motion`/`estimate_motion_cross_correlation_patches` now accept a `device` parameter which controls compute device while movie tensor may be stored elsewhere.
- Movie patch extraction, normalization, masking, and Fourier filtering are now a one-time computation and cached in `estimate_motion_optimizer.py` rather than re-computed per optimization iteration.
- Added Fourier cropping during patch pre-computation which _massively_ reduces downstream compute costs during optimization (10-25x runtime improvement) without loss of information.
- Global/patch cross-correlation motion estimation now supports downsample factor for movies to reduce memory/compute requirement in place of sub-pixel accuracy.
- Pixel coordinate grid now computed once and re-used in `correct_motion`/`correct_motion_slow`.
- Added `dose_weight_normalization_grid` and `dose_weight_frame_chunk` to support chunked dose weighting of extremely large movies