### PR TITLE
perf(torch-image-interpolation): sample without broadcasting the image over sample points

### DIFF
--- a/packages/primitives/torch-image-interpolation/src/torch_image_interpolation/image_interpolation_1d.py
+++ b/packages/primitives/torch-image-interpolation/src/torch_image_interpolation/image_interpolation_1d.py
@@ -45,7 +45,6 @@ def sample_image_1d(
     # set up for sampling with torch.nn.functional.grid_sample
     # coordinates: (..., ) -> (n, )
     coordinates, ps = einops.pack([coordinates], pattern='*')
-    n_samples = coordinates.shape[0]
     w = image.shape[-1]
 
     # handle complex input
@@ -58,15 +57,20 @@ def sample_image_1d(
 
     # For grid_sample to work with 1D, we need to add a dummy height dimension
     # and treat it as a 2D image with height=2
-    image = einops.repeat(image, 'c w -> c h w', h=2)
-
-    # Create batch of images, one per sample
-    image = einops.repeat(image, 'c h w -> b c h w', b=n_samples)
+    # torch.nn.functional.grid_sample is set up for sampling grids, so we sample
+    # a single grid of shape (1, n) containing all n coordinates.
+    #
+    # the sample points belong in the *grid's* spatial dimensions. broadcasting the
+    # image to (n, c, h, w) also produces correct results, but makes the backward
+    # pass materialise a dense (n, c, h, w) input-gradient before the broadcast
+    # sums it away - so peak memory and runtime scale with n * image_elems rather
+    # than with n. see https://github.com/teamtomo/teamtomo/issues/117
+    image = einops.repeat(image, 'c w -> 1 c h w', h=2)
 
     # Create grid coordinates
     # We need to add a dummy y coordinate (set to 0) to make it work with grid_sample
     dummy_y = torch.zeros_like(coordinates)
-    coords_2d = einops.rearrange([dummy_y, coordinates], "yx b -> b 1 1 yx")  # (b, 1, 1, 2)
+    coords_2d = einops.rearrange([dummy_y, coordinates], "yx b -> 1 1 b yx")  # (1, 1, b, 2)
 
     # Take the samples
     # We need to convert the coordinates to grid_sample format
@@ -87,10 +91,10 @@ def sample_image_1d(
 
     # Reconstruct complex valued samples if required
     if input_image_is_complex is True:
-        samples = einops.rearrange(samples, 'b (complex c) 1 1 -> b c complex', complex=2)
+        samples = einops.rearrange(samples, '1 (complex c) 1 b -> b c complex', complex=2)
         samples = utils.view_as_complex(samples.contiguous())  # (b, c)
     else:
-        samples = einops.rearrange(samples, 'b c 1 1 -> b c')
+        samples = einops.rearrange(samples, '1 c 1 b -> b c')
 
     # Set samples from outside of image to zero explicitly
     inside = torch.logical_and(coordinates >= 0, coordinates <= w - 1)

--- a/packages/primitives/torch-image-interpolation/src/torch_image_interpolation/image_interpolation_2d.py
+++ b/packages/primitives/torch-image-interpolation/src/torch_image_interpolation/image_interpolation_2d.py
@@ -47,7 +47,6 @@ def sample_image_2d(
     # set up for sampling with torch.nn.functional.grid_sample
     # shape (..., 2) -> (n, 2)
     coordinates, ps = einops.pack([coordinates], pattern='* yx')
-    n_samples = coordinates.shape[0]
     h, w = image.shape[-2:]
 
     # handle complex input
@@ -58,12 +57,16 @@ def sample_image_2d(
         image = torch.view_as_real(image)
         image = einops.rearrange(image, 'c h w complex -> (complex c) h w')
 
-    # torch.nn.functional.grid_sample is set up for sampling grids
-    # here we view our image as a batch of n_samples multi-channel images
-    # then sample a batch of (1x1) grids
-    # this enables sampling arbitrarily shaped arrays of coords
-    image = einops.repeat(image, 'c h w -> b c h w', b=n_samples)
-    coordinates = einops.rearrange(coordinates, 'b yx -> b 1 1 yx')  # b h w yx
+    # torch.nn.functional.grid_sample is set up for sampling grids, so we sample
+    # a single grid of shape (1, n) containing all n coordinates.
+    #
+    # the sample points belong in the *grid's* spatial dimensions. broadcasting the
+    # image to (n, c, h, w) also produces correct results, but makes the backward
+    # pass materialise a dense (n, c, h, w) input-gradient before the broadcast
+    # sums it away - so peak memory and runtime scale with n * image_elems rather
+    # than with n. see https://github.com/teamtomo/teamtomo/issues/117
+    image = einops.rearrange(image, 'c h w -> 1 c h w')
+    coordinates = einops.rearrange(coordinates, 'b yx -> 1 1 b yx')  # b h w yx
 
     # take the samples
     samples = F.grid_sample(
@@ -76,13 +79,13 @@ def sample_image_2d(
 
     # reconstruct complex valued samples if required
     if input_image_is_complex is True:
-        samples = einops.rearrange(samples, 'b (complex c) 1 1 -> b c complex', complex=2)
+        samples = einops.rearrange(samples, '1 (complex c) 1 b -> b c complex', complex=2)
         samples = utils.view_as_complex(samples.contiguous())  # (b, c)
     else:
-        samples = einops.rearrange(samples, 'b c 1 1 -> b c')
+        samples = einops.rearrange(samples, '1 c 1 b -> b c')
 
     # set samples from outside of image to zero explicitly
-    coordinates = einops.rearrange(coordinates, 'b 1 1 yx -> b yx')
+    coordinates = einops.rearrange(coordinates, '1 1 b yx -> b yx')
     image_shape = torch.as_tensor(image.shape[-2:]).to(device)
     inside = torch.logical_and(coordinates >= 0, coordinates <= image_shape - 1)
     inside = torch.all(inside, dim=-1)  # (b,)

--- a/packages/primitives/torch-image-interpolation/src/torch_image_interpolation/image_interpolation_3d.py
+++ b/packages/primitives/torch-image-interpolation/src/torch_image_interpolation/image_interpolation_3d.py
@@ -47,7 +47,6 @@ def sample_image_3d(
     # setup coordinates for sampling image with torch.nn.functional.grid_sample
     # shape (..., 3) -> (b, 3)
     coordinates, ps = einops.pack([coordinates], pattern='* zyx')
-    n_samples = coordinates.shape[0]
 
     # handle complex input
     if input_image_is_complex:
@@ -57,12 +56,16 @@ def sample_image_3d(
         image = torch.view_as_real(image)
         image = einops.rearrange(image, 'c d h w complex -> (complex c) d h w')
 
-    # torch.nn.functional.grid_sample is set up for sampling grids
-    # here we view our volume as a batch of n_samples multi-channel volumes
-    # then sample a batch of (1x1x1) grids
-    # this enables sampling arbitrarily shaped arrays of coords
-    image = einops.repeat(image, 'c d h w -> b c d h w', b=n_samples)
-    coordinates = einops.rearrange(coordinates, 'b zyx -> b 1 1 1 zyx')  # b d h w zyx
+    # torch.nn.functional.grid_sample is set up for sampling grids, so we sample
+    # a single grid of shape (1, 1, n) containing all n coordinates.
+    #
+    # the sample points belong in the *grid's* spatial dimensions. broadcasting the
+    # image to (n, c, d, h, w) also produces correct results, but makes the backward
+    # pass materialise a dense (n, c, d, h, w) input-gradient before the broadcast
+    # sums it away - so peak memory and runtime scale with n * image_elems rather
+    # than with n. see https://github.com/teamtomo/teamtomo/issues/117
+    image = einops.rearrange(image, 'c d h w -> 1 c d h w')
+    coordinates = einops.rearrange(coordinates, 'b zyx -> 1 1 1 b zyx')  # b d h w zyx
 
     # take the samples
     interpolation = 'bilinear' if interpolation == 'trilinear' else interpolation
@@ -76,13 +79,13 @@ def sample_image_3d(
 
     # reconstruct complex valued samples if required
     if input_image_is_complex is True:
-        samples = einops.rearrange(samples, 'b (complex c) 1 1 1 -> b c complex', complex=2)
+        samples = einops.rearrange(samples, '1 (complex c) 1 1 b -> b c complex', complex=2)
         samples = utils.view_as_complex(samples.contiguous())  # (b, c)
     else:
-        samples = einops.rearrange(samples, 'b c 1 1 1 -> b c')
+        samples = einops.rearrange(samples, '1 c 1 1 b -> b c')
 
     # set samples from outside of volume to zero
-    coordinates = einops.rearrange(coordinates, 'b 1 1 1 zyx -> b zyx')
+    coordinates = einops.rearrange(coordinates, '1 1 1 b zyx -> b zyx')
     volume_shape = torch.as_tensor(image.shape[-3:]).to(device)
     inside = torch.logical_and(coordinates >= 0, coordinates <= volume_shape - 1)
     inside = torch.all(inside, dim=-1)  # (b, d, h, w)

--- a/packages/primitives/torch-image-interpolation/tests/test_backward_memory.py
+++ b/packages/primitives/torch-image-interpolation/tests/test_backward_memory.py
@@ -1,0 +1,87 @@
+"""Regression tests for the memory cost of the backward pass.
+
+Sampling n points used to broadcast the image to `(n, c, *image_shape)` before
+calling `grid_sample`. That is free in the forward pass (a stride-0 view) but
+makes the backward pass materialise a dense `(n, c, *image_shape)` input
+gradient before the broadcast sums it away, so peak memory and runtime scale
+with `n * image_elems` instead of with `n`.
+
+See https://github.com/teamtomo/teamtomo/issues/117
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from torch_image_interpolation import (
+    sample_image_1d,
+    sample_image_2d,
+    sample_image_3d,
+)
+
+
+@pytest.fixture
+def grid_sample_batch_sizes(monkeypatch):
+    """Record the batch size of every `grid_sample` input during the test."""
+    seen = []
+    real = F.grid_sample
+
+    def spy(input, grid, **kwargs):  # noqa: A002
+        seen.append(input.shape[0])
+        return real(input, grid, **kwargs)
+
+    monkeypatch.setattr(F, "grid_sample", spy)
+    return seen
+
+
+@pytest.mark.parametrize("n_samples", [1, 64, 4096])
+@pytest.mark.parametrize(
+    "sample_fn, image_shape, coordinate_ndim",
+    [
+        (sample_image_1d, (32,), 0),
+        (sample_image_2d, (32, 32), 2),
+        (sample_image_3d, (32, 32, 32), 3),
+    ],
+)
+def test_image_is_not_broadcast_over_samples(
+    sample_fn, image_shape, coordinate_ndim, n_samples, grid_sample_batch_sizes
+):
+    """The image must be passed to `grid_sample` once, not once per sample."""
+    image = torch.rand(image_shape)
+    coordinate_shape = (n_samples,) + ((coordinate_ndim,) if coordinate_ndim else ())
+    coordinates = torch.rand(coordinate_shape) * (image_shape[-1] - 1)
+
+    sample_fn(image=image, coordinates=coordinates)
+
+    # a batch size of n_samples here is the bug: it costs n_samples x image
+    # in the backward pass
+    assert grid_sample_batch_sizes == [1]
+
+
+@pytest.mark.parametrize(
+    "sample_fn, image_shape, coordinate_ndim",
+    [
+        (sample_image_1d, (16,), 0),
+        (sample_image_2d, (16, 16), 2),
+        (sample_image_3d, (16, 16, 16), 3),
+    ],
+)
+def test_gradients_flow_to_image_and_coordinates(
+    sample_fn, image_shape, coordinate_ndim
+):
+    """Sampling is differentiable with respect to both image and coordinates."""
+    image = torch.rand(image_shape, dtype=torch.float64, requires_grad=True)
+    coordinate_shape = (7,) + ((coordinate_ndim,) if coordinate_ndim else ())
+    # stay off exact voxel centres: the interpolant is only piecewise linear,
+    # so its derivative is undefined on the grid lines
+    coordinates = (
+        torch.rand(coordinate_shape, dtype=torch.float64) * (image_shape[-1] - 3) + 1.1
+    )
+    coordinates.requires_grad_(True)
+
+    torch.autograd.gradcheck(
+        lambda i, c: sample_fn(image=i, coordinates=c),
+        (image, coordinates),
+        eps=1e-6,
+        atol=1e-8,
+    )


### PR DESCRIPTION
Fixes #117. @mgiammar you offered to look over a PR — here it is.

## The change

`sample_image_1d/2d/3d` broadcast the whole image to `(n, c, *image_shape)` before calling `grid_sample`, then sampled a batch of n 1-element grids:

```python
image = einops.repeat(image, 'c d h w -> b c d h w', b=n_samples)
coordinates = einops.rearrange(coordinates, 'b zyx -> b 1 1 1 zyx')
```

That broadcast is free in the forward pass — it is a stride-0 view. It is not free in the backward pass: `grid_sample` must materialise a dense `(n, c, *image_shape)` input gradient before the broadcast sums it away, so peak memory and runtime scale with `n * image_elems` instead of with `n`.

`grid_sample` already takes an arbitrary number of sample points in the **grid's** own spatial dimensions, which is where they belong. So the batch dimension stays at 1 and the points move into the grid:

```python
image = einops.rearrange(image, 'c d h w -> 1 c d h w')
coordinates = einops.rearrange(coordinates, 'b zyx -> 1 1 1 b zyx')
```

Only the packing changes. The complex-as-channels workaround, `padding_mode='border'`, `align_corners=True` and the out-of-range masking are all untouched, and the unpacking rearranges follow the new axis order.

Note this also covers **`sample_image_1d`**, which has the same broadcast at line 64 — I had only reported 2D and 3D in the issue.

## Effect

Sampling 4096 points from a `(64, 64, 33)` complex64 volume (a padded rfft volume as `torch-fourier-slice` produces), forward + backward, each row measured in a **dedicated process** since `ru_maxrss` is a process high-water mark. torch 2.6.0, CPU:

| | peak RSS | fwd + bwd |
|---|---|---|
| before | 2.53 GB | 3.704 s |
| after | **0.26 GB** | **0.003 s** |

For `torch_fourier_slice.project_3d_to_2d`, where `n = B*K*N²` and `image_elems ~ (2N)³/2`, this takes the backward from roughly `O(B*K*N⁵)` to `O(B*K*N²)`. On one 40-tilt cryo-ET particle that is ~40 GB → ~2.3 MB at N=32, and ~40 TB → ~133 MB at N=128.

## Equivalence

Checked patched vs. unpatched in separate processes across real, multichannel and complex inputs, in 1D/2D/3D, for every interpolation mode, with coordinates deliberately spilling outside the image so the masking path is covered:

- **outputs: exactly equal** (`max|Δ| = 0.00e+00`) on all 11 cases
- **gradients w.r.t. image and coordinates: exactly equal**, except `bicubic` 2D image-grad at `2.4e-07` — float32 accumulation order, ~1 ulp

The existing 42 tests pass unchanged.

## Tests added

`tests/test_backward_memory.py`:

- `test_image_is_not_broadcast_over_samples` — spies on `F.grid_sample` and asserts the input batch size is 1 regardless of `n_samples`. This pins the property directly rather than trying to assert on memory, so it is deterministic and instant. It fails on `main` (`assert [64] == [1]`).
- `test_gradients_flow_to_image_and_coordinates` — `gradcheck` in float64 over both arguments for all three dimensionalities, so the new packing cannot silently change the gradient.

---

@alisterburt — happy to look at the experimental Fourier slicing API separately; this one is deliberately confined to the existing Python API since, as you said, it is worth fixing while it is still there.

There is a second, independent blocker to backprop through `torch-fourier-slice` that this PR does **not** address — `extract_central_slices_rfft_3d` mutating the caller's `rotation_matrices` in place. I have opened that as a separate PR to keep the two reviewable on their own merits.