### PR TITLE
fix(torch-fourier-slice): stop writing into the caller's rotation matrices

### DIFF
--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_3d.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_3d.py
@@ -168,8 +168,14 @@ def extract_central_slices_rfft_3d(
     rotation_matrices = rotation_matrices.to(torch.float32)
 
     if rot_tolerance is not None:
+        # out of place: an in-place write here would modify the caller's array,
+        # and would raise if the caller's matrices require grad
         near_zero_elements = torch.abs(rotation_matrices) < rot_tolerance
-        rotation_matrices[near_zero_elements] = 0.0
+        rotation_matrices = torch.where(
+            near_zero_elements,
+            torch.zeros_like(rotation_matrices),
+            rotation_matrices,
+        )
 
     if not zyx_matrices:
         rotation_matrices = torch.flip(rotation_matrices, dims=(-2, -1))
@@ -339,8 +345,14 @@ def extract_central_slices_rfft_3d_multichannel(
     rotation_matrices = rotation_matrices.to(torch.float32)
 
     if rot_tolerance is not None:
+        # out of place: an in-place write here would modify the caller's array,
+        # and would raise if the caller's matrices require grad
         near_zero_elements = torch.abs(rotation_matrices) < rot_tolerance
-        rotation_matrices[near_zero_elements] = 0.0
+        rotation_matrices = torch.where(
+            near_zero_elements,
+            torch.zeros_like(rotation_matrices),
+            rotation_matrices,
+        )
 
     if not zyx_matrices:
         rotation_matrices = torch.flip(rotation_matrices, dims=(-2, -1))

--- a/packages/primitives/torch-fourier-slice/tests/test_autograd.py
+++ b/packages/primitives/torch-fourier-slice/tests/test_autograd.py
@@ -1,0 +1,94 @@
+"""Tests for differentiability of, and absence of side effects in, slice extraction."""
+
+import pytest
+import torch
+
+from torch_fourier_slice import project_3d_to_2d
+from torch_fourier_slice.slice_extraction import (
+    extract_central_slices_rfft_3d,
+    extract_central_slices_rfft_3d_multichannel,
+)
+
+
+def _rfft_volume(n: int = 16, n_channels: int | None = None) -> torch.Tensor:
+    """A volume in the fftshifted rfft layout the extraction functions expect."""
+    shape = (n, n, n) if n_channels is None else (n_channels, n, n, n)
+    volume = torch.rand(shape)
+    dft = torch.fft.rfftn(torch.fft.ifftshift(volume, dim=(-3, -2, -1)), dim=(-3, -2, -1))
+    return torch.fft.fftshift(dft, dim=(-3, -2))
+
+
+@pytest.mark.parametrize(
+    "extract_fn, n_channels",
+    [
+        (extract_central_slices_rfft_3d, None),
+        (extract_central_slices_rfft_3d_multichannel, 2),
+    ],
+)
+def test_extraction_does_not_modify_rotation_matrices(extract_fn, n_channels):
+    """Extraction must not write into the caller's rotation matrices.
+
+    `rot_tolerance` snaps near-zero matrix elements to zero. Doing that in place
+    silently zeroed elements of the caller's own array, because the preceding
+    `.to(torch.float32)` is a no-op that returns the same tensor when the input
+    is already float32.
+    """
+    rotation_matrices = torch.eye(3).expand(4, 3, 3).contiguous()
+    # a legitimately tiny, non-zero element, below the default rot_tolerance
+    rotation_matrices[0, 0, 1] = 1e-12
+    expected = rotation_matrices.clone()
+
+    extract_fn(volume_rfft=_rfft_volume(n_channels=n_channels),
+               rotation_matrices=rotation_matrices)
+
+    assert torch.equal(rotation_matrices, expected)
+
+
+@pytest.mark.parametrize(
+    "extract_fn, n_channels",
+    [
+        (extract_central_slices_rfft_3d, None),
+        (extract_central_slices_rfft_3d_multichannel, 2),
+    ],
+)
+def test_extraction_accepts_rotation_matrices_requiring_grad(extract_fn, n_channels):
+    """Rotation matrices may be optimised, so they may be autograd leaves.
+
+    The in-place `rot_tolerance` write raised
+    "a leaf Variable that requires grad is being used in an in-place operation".
+    """
+    rotation_matrices = torch.eye(3).expand(4, 3, 3).contiguous().clone()
+    rotation_matrices.requires_grad_(True)
+
+    slices = extract_fn(volume_rfft=_rfft_volume(n_channels=n_channels),
+                        rotation_matrices=rotation_matrices)
+    slices.abs().sum().backward()
+
+    assert rotation_matrices.grad is not None
+    assert torch.all(torch.isfinite(rotation_matrices.grad))
+
+
+def test_project_3d_to_2d_is_differentiable_wrt_rotation_matrices():
+    """Gradients reach the rotation matrices through the whole projection."""
+    volume = torch.rand(16, 16, 16)
+    rotation_matrices = torch.eye(3).expand(3, 3, 3).contiguous().clone()
+    rotation_matrices.requires_grad_(True)
+
+    project_3d_to_2d(volume, rotation_matrices).sum().backward()
+
+    grad = rotation_matrices.grad
+    assert grad is not None
+    assert torch.all(torch.isfinite(grad))
+    assert torch.any(grad != 0)
+
+
+def test_project_3d_to_2d_is_differentiable_wrt_volume():
+    """Gradients reach the volume, so it can be optimised by reprojection."""
+    volume = torch.rand(16, 16, 16, requires_grad=True)
+    rotation_matrices = torch.eye(3).expand(3, 3, 3).contiguous()
+
+    project_3d_to_2d(volume, rotation_matrices).sum().backward()
+
+    assert volume.grad is not None
+    assert torch.all(torch.isfinite(volume.grad))
+    assert torch.any(volume.grad != 0)


### PR DESCRIPTION
Found while working on #117. This is **independent of that issue and of #118** — it is a separate blocker to backprop through `torch-fourier-slice`, and it is also a plain aliasing bug that bites without autograd at all.

## The bug

`extract_central_slices_rfft_3d` (and `extract_central_slices_rfft_3d_multichannel`) snap near-zero rotation matrix elements to zero in place:

```python
rotation_matrices = rotation_matrices.to(torch.float32)

if rot_tolerance is not None:
    near_zero_elements = torch.abs(rotation_matrices) < rot_tolerance
    rotation_matrices[near_zero_elements] = 0.0     # <-- writes into the caller's tensor
```

`.to(torch.float32)` is a **no-op that returns the same tensor** when the input is already float32 — which it is, for essentially every caller. So the snap lands on the array the caller passed in.

**1. It makes rotation matrices non-differentiable.**

```python
R = torch.eye(3).expand(4, 3, 3).contiguous().clone().requires_grad_(True)
project_3d_to_2d(volume, R)
# RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
```

This is the case that matters for pose refinement and for learned pose estimation — you cannot get a gradient to the orientation you are trying to optimise. Gradients to the *volume* work fine, which is why this has gone unnoticed.

**2. It silently corrupts the caller's array even with autograd off.**

```python
R = torch.eye(3).expand(4, 3, 3).contiguous().clone()
R[0, 0, 1] = 1e-12                # a legitimately tiny, non-zero element
before = R.clone()
extract_central_slices_rfft_3d(volume_rfft=dft, rotation_matrices=R)
torch.equal(before, R)            # False — R[0,0,1] is now 0.0
```

`rot_tolerance` defaults to `1e-8`, not `None`, so this path runs on every call. A caller reusing its rotation matrices gets a quietly different array back with no diagnostic.

## The fix

`torch.where`, at both call sites. Forward values are unchanged, because the branch selects exactly the elements the in-place write targeted. Gradient semantics are unchanged too — a hard threshold contributes no gradient through the snapped elements either way.

I kept the change to the aliasing itself and did not touch the surrounding `.to(torch.float32)` downcast, which is a separate question.

## Verification

Patched vs. `main`, in separate processes, **bit-identical** (`max|Δ| = 0.00e+00`) on all of:

- `extract_central_slices_rfft_3d` for `zyx_matrices` in {True, False} × `rot_tolerance` in {None, 1e-8, 1e-3}
- `extract_central_slices_rfft_3d_multichannel`
- `project_3d_to_2d`, with and without `zyx_matrices`

The orientations used are the ZYZ sets from `tests/test_extract_central_slices_rfft_3d.py` — the axis-aligned and 180°-apart pairs that produce exact zeros and conjugate slices, i.e. precisely the ones that hit the `rot_tolerance` branch hardest.

`backproject_2d_to_3d` shows a `7e-9` delta, but that is *not* from this change: `main` compared against itself across two runs differs by `1.1e-8` on the same tensor. `index_put_(accumulate=True)` is not run-to-run deterministic. Nothing in the backprojection path is touched here.

`tests/test_torch_fourier_slice.py` — 37 passed, unchanged.

⚠️ I could **not** run `tests/test_extract_central_slices_rfft_3d.py` locally: it imports `urllib3` and `ttsim3d` and downloads a PDB entry, neither of which is available in my environment. The equivalence check above is my substitute for it; CI will cover the real thing.

## Tests added

`tests/test_autograd.py` — 6 tests, 5 of which fail on `main`:

- `test_extraction_does_not_modify_rotation_matrices` — the aliasing, for both extractors
- `test_extraction_accepts_rotation_matrices_requiring_grad` — the `RuntimeError`, for both extractors
- `test_project_3d_to_2d_is_differentiable_wrt_rotation_matrices` — end to end
- `test_project_3d_to_2d_is_differentiable_wrt_volume` — passes on `main`; there to keep it that way

These are cheap. Gradients w.r.t. rotations alone do not need `grad_input` from `grid_sample`, so they do not hit the memory problem in #117 and this PR does not depend on #118.