### PR TITLE
fix(torch-fourier-slice): reduce peak memory usage on sinc2 correction

### DIFF
--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/backproject.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/backproject.py
@@ -1,11 +1,11 @@
 import torch
 import torch.nn.functional as F
-from torch_grid_utils import fftfreq_grid
 
 from .slice_insertion import (
     insert_central_slices_rfft_3d,
     insert_central_slices_rfft_3d_multichannel,
 )
+from .volume_utils import separable_sinc2_correction
 
 
 def backproject_2d_to_3d(
@@ -100,14 +100,9 @@ def backproject_2d_to_3d(
     dft = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=volume_shape)
     dft = torch.fft.fftshift(dft, dim=(-3, -2, -1))  # center in real space
 
-    # correct for convolution with linear interpolation kernel. The kernel is
-    # separable per-axis, so the correction is a product of 1D sincs, not
-    # the sinc of the radial frequency. See issue #65 for more info.
-    grid = fftfreq_grid(
-        image_shape=dft.shape, rfft=False, fftshift=True, norm=False, device=dft.device
-    )
-    sinc = torch.sinc(grid[..., 0]) * torch.sinc(grid[..., 1]) * torch.sinc(grid[..., 2])
-    dft = dft / sinc**2
+    # correct for convolution with linear interpolation kernel. See issue #65 for info.
+    sinc2 = separable_sinc2_correction(dft.shape, device=dft.device)
+    dft = dft / sinc2
 
     # unpad
     if pad_factor > 1.0:
@@ -208,18 +203,9 @@ def backproject_2d_to_3d_multichannel(
     dft = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=volume_shape)
     dft = torch.fft.fftshift(dft, dim=(-3, -2, -1))  # center in real space
 
-    # correct for convolution with linear interpolation kernel. The kernel is
-    # separable per-axis, so the correction is a product of 1D sincs, not
-    # the sinc of the radial frequency. See issue #65 for more info.
-    grid = fftfreq_grid(
-        image_shape=dft.shape[-3:],
-        rfft=False,
-        fftshift=True,
-        norm=False,
-        device=dft.device,
-    )
-    sinc = torch.sinc(grid[..., 0]) * torch.sinc(grid[..., 1]) * torch.sinc(grid[..., 2])
-    dft = dft / sinc**2
+    # correct for convolution with linear interpolation kernel. See issue #65 for info.
+    sinc2 = separable_sinc2_correction(dft.shape, device=dft.device)
+    dft = dft / sinc2
 
     # unpad
     if pad_factor > 1.0:

--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
@@ -9,7 +9,11 @@ from .slice_extraction import (
     transform_slice_2d,
     transform_slice_2d_multichannel,
 )
-from .volume_utils import compute_cube_face_averages, compute_square_edge_averages
+from .volume_utils import (
+    compute_cube_face_averages,
+    compute_square_edge_averages,
+    separable_sinc2_correction,
+)
 
 
 def project_3d_to_2d(
@@ -87,20 +91,9 @@ def project_3d_to_2d(
     volume_shape = tuple(volume.shape[-3:])
 
     # divide by sinc^2 in real space to correct for the effect of trilinear
-    # interpolation during slice extraction. The interpolation kernel is
-    # separable per-axis, so the correction is a product of 1D sincs, not
-    # the sinc of the radial frequency. See issue #65 for more info.
-    grid = fftfreq_grid(
-        image_shape=volume_shape,
-        rfft=False,
-        fftshift=True,
-        norm=False,
-        device=volume.device,
-    )
-    sinc = (
-        torch.sinc(grid[..., 0]) * torch.sinc(grid[..., 1]) * torch.sinc(grid[..., 2])
-    )
-    volume = volume / sinc**2
+    # interpolation during slice extraction. See issue #65 for more info.
+    sinc2 = separable_sinc2_correction(volume_shape, device=volume.device)
+    volume = volume / sinc2
 
     # calculate DFT
     # volume center to array origin
@@ -225,20 +218,9 @@ def project_3d_to_2d_multichannel(
     volume_shape = tuple(volume.shape[-3:])
 
     # divide by sinc^2 in real space to correct for the effect of trilinear
-    # interpolation during slice extraction. The interpolation kernel is
-    # separable per-axis, so the correction is a product of 1D sincs, not
-    # the sinc of the radial frequency. See issue #65 for more info.
-    grid = fftfreq_grid(
-        image_shape=volume_shape,
-        rfft=False,
-        fftshift=True,
-        norm=False,
-        device=volume.device,
-    )
-    sinc = (
-        torch.sinc(grid[..., 0]) * torch.sinc(grid[..., 1]) * torch.sinc(grid[..., 2])
-    )
-    volume = volume / sinc**2
+    # interpolation during slice extraction. See issue #65 for more info.
+    sinc2 = separable_sinc2_correction(volume_shape, device=volume.device)
+    volume = volume / sinc2
 
     # calculate DFT
     # volume center to array origin
@@ -341,19 +323,10 @@ def project_2d_to_1d(
     # set the shape as a variable
     image_shape = tuple(image.shape[-2:])
 
-    # divide by sinc^2 in real space to correct for the effect of linear
-    # interpolation during slice extraction. The interpolation kernel is
-    # separable per-axis, so the correction is a product of 1D sincs, not
-    # the sinc of the radial frequency. See issue #65 for more info.
-    grid = fftfreq_grid(
-        image_shape=image_shape,
-        rfft=False,
-        fftshift=True,
-        norm=False,
-        device=image.device,
-    )
-    sinc = torch.sinc(grid[..., 0]) * torch.sinc(grid[..., 1])
-    image = image / sinc**2
+    # divide by sinc^2 in real space to correct for the effect of trilinear
+    # interpolation during slice extraction. See issue #65 for more info.
+    sinc2 = separable_sinc2_correction(volume_shape, device=volume.device)
+    volume = volume / sinc2
 
     # calculate DFT
     dft = torch.fft.ifftshift(image, dim=(-2, -1))  # image center to array origin

--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/project.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn.functional as F
-from torch_grid_utils import fftfreq_grid
 
 from .slice_extraction import (
     extract_central_slices_rfft_2d,
@@ -325,8 +324,8 @@ def project_2d_to_1d(
 
     # divide by sinc^2 in real space to correct for the effect of trilinear
     # interpolation during slice extraction. See issue #65 for more info.
-    sinc2 = separable_sinc2_correction(volume_shape, device=volume.device)
-    volume = volume / sinc2
+    sinc2 = separable_sinc2_correction(image_shape, device=image.device)
+    image = image / sinc2
 
     # calculate DFT
     dft = torch.fft.ifftshift(image, dim=(-2, -1))  # image center to array origin

--- a/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/volume_utils.py
+++ b/packages/primitives/torch-fourier-slice/src/torch_fourier_slice/volume_utils.py
@@ -1,6 +1,36 @@
 import torch
 
 
+def separable_sinc2_correction(
+    shape: tuple[int, ...], device: torch.device | None = None
+) -> torch.Tensor:
+    """sinc^2 correction for linear interpolation, applied per-axis.
+
+    Parameters
+    ----------
+    shape: tuple[int, ...]
+        Shape of the real-space array to correct.
+    device: torch.device | None
+        PyTorch device on which the returned correction will be stored.
+
+    Returns
+    -------
+    correction: torch.Tensor
+        `shape` array of sinc^2 correction factors, broadcastable against
+        an array of `shape` for elementwise division.
+    """
+    ndim = len(shape)
+    correction = torch.ones((), device=device)
+
+    for axis, size in enumerate(shape):
+        freq = torch.fft.fftshift(torch.fft.fftfreq(size, device=device))
+        view_shape = [1] * ndim
+        view_shape[axis] = size
+        correction = correction * torch.sinc(freq).view(view_shape)  # memory efficient
+
+    return correction**2
+
+
 def boundary_shell_average(
     volume: torch.Tensor, n: int, n_spatial_dims: int
 ) -> torch.Tensor:


### PR DESCRIPTION
Uses views and broadcasting to avoid materializing a dense second volume for the sinc2 correction. Since the grid is separable along x/y/z, there's no issue viewing each correction along the dimensions.

Updated code since I ran into a new OOM error on GPU hardware after the sinc2 correction was added