### PR TITLE
fix(torch-ctf): support per-image Zernike coefficients

### DIFF
--- a/packages/primitives/torch-ctf/src/torch_ctf/ctf_aberrations.py
+++ b/packages/primitives/torch-ctf/src/torch_ctf/ctf_aberrations.py
@@ -227,6 +227,35 @@ def resolve_odd_zernikes(
     return zernikes
 
 
+def _as_zernike_coeff(
+    coeff: float | torch.Tensor, dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    """Return a Zernike coefficient as a tensor on the grid's dtype and device.
+
+    Parameters
+    ----------
+    coeff: float | torch.Tensor
+        Zernike coefficient. A scalar applies to every image; a tensor of
+        shape (..., 1, 1) gives one coefficient per image in a batch.
+    dtype: torch.dtype
+        Dtype of the coordinate grid the coefficient will be applied to.
+    device: torch.device
+        Device of the coordinate grid the coefficient will be applied to.
+
+    Returns
+    -------
+    coeff: torch.Tensor
+        The coefficient as a tensor.
+    """
+    if isinstance(coeff, int | float):
+        return torch.tensor(coeff, dtype=dtype, device=device)
+    if isinstance(coeff, torch.Tensor):
+        return coeff.to(device=device, dtype=dtype)
+    raise TypeError(
+        f"Zernike coefficient must be float or torch.Tensor, got {type(coeff)}"
+    )
+
+
 def apply_odd_zernikes(
     odd_zernikes: dict | None,
     rho: torch.Tensor,
@@ -240,8 +269,9 @@ def apply_odd_zernikes(
     Parameters
     ----------
     odd_zernikes: dict | None
-        Odd Zernike coefficients. Values can be floats or tensors.
-        Floats will be converted to tensors for differentiability.
+        Odd Zernike coefficients. Values can be floats or tensors. A
+        coefficient of shape (..., 1, 1) is treated as one value per image
+        and broadcasts the returned phase up to (..., h, w).
     rho: torch.Tensor
         Radial coordinate.
     theta: torch.Tensor
@@ -268,29 +298,18 @@ def apply_odd_zernikes(
         return torch.zeros_like(rho)
 
     phase = torch.zeros_like(rho)
-    device = rho.device
-    dtype = rho.dtype
 
     for name, coeff in odd_zernikes.items():
-        # Convert float to tensor for differentiability
-        if isinstance(coeff, int | float):
-            coeff = torch.tensor(coeff, dtype=dtype, device=device, requires_grad=True)
-        elif isinstance(coeff, torch.Tensor):
-            # Ensure tensor is on correct device and dtype
-            coeff = coeff.to(device=device, dtype=dtype)
-        else:
-            raise TypeError(
-                f"Zernike coefficient must be float or torch.Tensor, got {type(coeff)}"
-            )
+        coeff = _as_zernike_coeff(coeff, dtype=rho.dtype, device=rho.device)
 
         if name == "Z31c":  # beam tilt / axial coma x
-            phase += coeff * rho**3 * torch.cos(theta)
+            phase = phase + coeff * rho**3 * torch.cos(theta)
         elif name == "Z31s":  # beam tilt / axial coma y
-            phase += coeff * rho**3 * torch.sin(theta)
+            phase = phase + coeff * rho**3 * torch.sin(theta)
         elif name == "Z33c":  # trefoil
-            phase += coeff * rho**3 * torch.cos(3 * theta)
+            phase = phase + coeff * rho**3 * torch.cos(3 * theta)
         elif name == "Z33s":
-            phase += coeff * rho**3 * torch.sin(3 * theta)
+            phase = phase + coeff * rho**3 * torch.sin(3 * theta)
         else:
             raise ValueError(f"Unknown odd Zernike: {name}")
 
@@ -311,8 +330,9 @@ def apply_even_zernikes(
         Even Zernike coefficients, keyed by name. Supported names are
         ``Z42c``/``Z42s`` (secondary astigmatism), ``Z44c``/``Z44s``
         (four-fold astigmatism) and ``Z60`` (sixth-order spherical).
-        Values can be floats or tensors. Floats will be converted to
-        tensors for differentiability.
+        Values can be floats or tensors. A coefficient of shape
+        (..., 1, 1) is treated as one value per image and broadcasts the
+        returned phase up to (..., h, w).
     total_phase_shift: torch.Tensor
         Total phase shift.
     rho: torch.Tensor
@@ -326,31 +346,20 @@ def apply_even_zernikes(
         Phase shift with even Zernike coefficients applied.
     """
     chi = total_phase_shift.clone()
-    device = rho.device
-    dtype = rho.dtype
 
     for name, coeff in even_zernikes.items():
-        # Convert float to tensor for differentiability
-        if isinstance(coeff, int | float):
-            coeff = torch.tensor(coeff, dtype=dtype, device=device, requires_grad=True)
-        elif isinstance(coeff, torch.Tensor):
-            # Ensure tensor is on correct device and dtype
-            coeff = coeff.to(device=device, dtype=dtype)
-        else:
-            raise TypeError(
-                f"Zernike coefficient must be float or torch.Tensor, got {type(coeff)}"
-            )
+        coeff = _as_zernike_coeff(coeff, dtype=rho.dtype, device=rho.device)
 
         if name == "Z42c":  # secondary (2-fold) astigmatism
-            chi += coeff * rho**4 * torch.cos(2 * theta)
+            chi = chi + coeff * rho**4 * torch.cos(2 * theta)
         elif name == "Z42s":
-            chi += coeff * rho**4 * torch.sin(2 * theta)
+            chi = chi + coeff * rho**4 * torch.sin(2 * theta)
         elif name == "Z44c":  # 4-fold astigmatism
-            chi += coeff * rho**4 * torch.cos(4 * theta)
+            chi = chi + coeff * rho**4 * torch.cos(4 * theta)
         elif name == "Z44s":
-            chi += coeff * rho**4 * torch.sin(4 * theta)
+            chi = chi + coeff * rho**4 * torch.sin(4 * theta)
         elif name == "Z60":  # 6th-order spherical
-            chi += coeff * rho**6
+            chi = chi + coeff * rho**6
         else:
             raise ValueError(f"Unknown even Zernike: {name}")
     return chi

--- a/packages/primitives/torch-ctf/tests/test_ctf_aberrations.py
+++ b/packages/primitives/torch-ctf/tests/test_ctf_aberrations.py
@@ -8,6 +8,7 @@ from torch_ctf import (
     apply_even_zernikes,
     apply_odd_zernikes,
     beam_tilt_to_zernike_coeffs,
+    calculate_ctf_2d,
     calculate_relativistic_electron_wavelength,
     resolve_odd_zernikes,
 )
@@ -566,3 +567,86 @@ def test_apply_even_zernikes_secondary_astigmatism():
 
     assert torch.allclose(result, expected)
     assert torch.all(torch.isfinite(result))
+
+
+def test_apply_odd_zernikes_per_image_coefficients():
+    """A per-image odd coefficient broadcasts an unbatched grid up to a batch."""
+    rho = torch.full((10, 10), 0.5)
+    theta = torch.linspace(0, 2 * torch.pi, 100).reshape(10, 10)
+    coeffs = torch.tensor([0.1, 0.2, 0.3]).view(3, 1, 1)
+
+    result = apply_odd_zernikes(
+        odd_zernikes={"Z33c": coeffs},
+        rho=rho,
+        theta=theta,
+        voltage_kv=torch.tensor(300.0),
+        spherical_aberration_mm=torch.tensor(2.7),
+    )
+
+    assert result.shape == (3, 10, 10)
+    for i, coeff in enumerate(coeffs.flatten()):
+        expected = apply_odd_zernikes(
+            odd_zernikes={"Z33c": coeff},
+            rho=rho,
+            theta=theta,
+            voltage_kv=torch.tensor(300.0),
+            spherical_aberration_mm=torch.tensor(2.7),
+        )
+        assert torch.allclose(result[i], expected)
+
+
+def test_apply_even_zernikes_per_image_coefficients():
+    """A per-image even coefficient broadcasts an unbatched phase shift."""
+    rho = torch.full((10, 10), 0.5)
+    theta = torch.linspace(0, 2 * torch.pi, 100).reshape(10, 10)
+    total_phase_shift = torch.zeros((10, 10))
+    coeffs = torch.tensor([0.1, 0.2, 0.3]).view(3, 1, 1)
+
+    result = apply_even_zernikes(
+        even_zernikes={"Z44c": coeffs},
+        total_phase_shift=total_phase_shift,
+        rho=rho,
+        theta=theta,
+    )
+
+    assert result.shape == (3, 10, 10)
+    expected = coeffs * rho**4 * torch.cos(4 * theta)
+    assert torch.allclose(result, expected)
+
+
+def test_calculate_ctf_2d_per_image_zernikes():
+    """Per-image Zernikes through the 2D CTF match per-image scalar calls."""
+    defocus = torch.tensor([1.0, 1.5, 2.0])
+    trefoil = torch.tensor([0.05, 0.10, 0.15])
+    kwargs = {
+        "astigmatism": torch.zeros(3),
+        "astigmatism_angle": torch.zeros(3),
+        "voltage": 300.0,
+        "spherical_aberration": 2.7,
+        "amplitude_contrast": 0.1,
+        "phase_shift": 0.0,
+        "pixel_size": 1.0,
+        "image_shape": (32, 32),
+        "rfft": False,
+        "fftshift": False,
+    }
+
+    batched = calculate_ctf_2d(
+        defocus=defocus,
+        odd_zernike_coeffs={"Z33c": trefoil.view(3, 1, 1)},
+        **kwargs,
+    )
+
+    assert batched.shape == (3, 32, 32)
+    single_kwargs = {
+        **kwargs,
+        "astigmatism": torch.zeros(1),
+        "astigmatism_angle": torch.zeros(1),
+    }
+    for i in range(3):
+        single = calculate_ctf_2d(
+            defocus=defocus[i].expand(1),
+            odd_zernike_coeffs={"Z33c": trefoil[i]},
+            **single_kwargs,
+        )
+        assert torch.allclose(batched[i], single[0], atol=1e-6)


### PR DESCRIPTION
Zernike coefficients don't work with batched inputs. Passing one coefficient
per image raises, where defocus, astigmatism, voltage, Cs, amplitude contrast
and phase shift all broadcast:

```python
calculate_ctf_2d(
    defocus=torch.linspace(1.0, 2.0, 3),
    astigmatism=torch.zeros(3),
    astigmatism_angle=torch.zeros(3),
    odd_zernike_coeffs={"Z33c": torch.full((3, 1, 1), 0.1)},  # per-image trefoil
    voltage=300.0, spherical_aberration=2.7, amplitude_contrast=0.1,
    phase_shift=0.0, pixel_size=1.0, image_shape=(64, 64),
    rfft=False, fftshift=False,
)
# RuntimeError: output with shape [64, 64] doesn't match the broadcast shape [3, 64, 64]
```

`apply_odd_zernikes` accumulates phase **in place** into a tensor sized from
the unbatched `(h, w)` grid. A coefficient of shape `(b, 1, 1)` makes the
right-hand side `(b, h, w)`, which an in-place add cannot expand into.

Real data hits this: trefoil and beam tilt are per-optics-group properties, and
a CryoSPARC `.cs` file stores them per particle.

`apply_even_zernikes` has the same defect, though it surfaces less often. It
starts from `total_phase_shift.clone()`, which is already batched whenever
defocus is, so the in-place add usually works. It still fails for a per-image
Zernike with a scalar defocus.

**Fix:** accumulate out of place in both functions. Scalar and already-batched
inputs behave as before, and only calls that used to raise now succeed. Tensor
coefficients already work for autograd (*allow tensor or float coefficients for
differentiability*, pre-monorepo); this extends them to batched shapes. The
float-to-tensor conversion duplicated in both loops moves into
`_as_zernike_coeff`, with the same `TypeError` message.

**Tests:** three added, all failing on `main` and passing here: per-image odd,
per-image even, and end to end through `calculate_ctf_2d`, following the
existing `test_2d_ctf_batch`. Full suite passes, ruff and mypy clean.

**Not changed:** a `(b,)`-shaped coefficient still fails, since Zernike
coefficients skip the `"... -> ... 1 1"` rearrange `_prepare_inputs` applies to
every other parameter. Adding it would change behaviour rather than fix a bug:
a `(1,)` coefficient would start returning `(1, h, w)`, which
`test_apply_odd_zernikes_with_beam_tilt` asserts against. A `(1,)`-shaped
*defocus* already returns `(1, h, w)` today. Happy to fold it in if you want
the consistency.
