### PR TITLE
fix(torch-fourier-filter): stop leaking default device across the test session

### DIFF
--- a/packages/primitives/torch-fourier-filter/tests/conftest.py
+++ b/packages/primitives/torch-fourier-filter/tests/conftest.py
@@ -4,4 +4,5 @@ import torch
 
 @pytest.fixture(autouse=True)
 def set_default_device():
-    torch.set_default_device("cpu")
+    with torch.device("cpu"):
+        yield


### PR DESCRIPTION
`torch-fourier-filter/tests/conftest.py` has an autouse fixture that calls `torch.set_default_device("cpu")` and never restores it. This mutates PyTorch's process-global default device for the rest of the pytest session, not just for `torch-fourier-filter`'s own tests.

Under a workspace-wide test run, this pollution causes a spurious CUDA-only failure in an unrelated package: `torch-tilt-series::test_project_points_origin[cuda]` fails with

```
RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cuda:0, different from other tensors on cpu
```

With the default device left at `"cpu"`, `torch.as_tensor()` on an already-CUDA tensor (used inside `torch_affine_utils.homogenise_coordinates`) silently copies it to CPU instead of leaving it alone — so a downstream matmul in `TiltSeries.project_points` ends up mixing CPU and CUDA tensors, even though `project_points` itself handles devices correctly.

Fix: scope the fixture to each test via `torch.device("cpu")` as a context manager, so the default device resets after every test instead of leaking into whatever runs next.

Verified:
- `torch-fourier-filter`'s own suite still passes (its one pre-existing, unrelated CUDA-precision failure in `test_phase_permutation_cuton_zero` is unaffected).
- Full workspace suite: `test_project_points_origin[cuda]` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)