### PR TITLE
fix(torch-find-peaks): seed noise generator at data-generation time

### DIFF
--- a/packages/primitives/torch-find-peaks/tests/_utils.py
+++ b/packages/primitives/torch-find-peaks/tests/_utils.py
@@ -4,20 +4,23 @@ from torch_grid_utils import coordinate_grid
 from torch_find_peaks.gaussians import Gaussian2D, Gaussian3D
 
 
-def create_test_image(size:int=100, peaks: torch.tensor = torch.tensor([]), noise_level=0.1):
+def create_test_image(size:int=100, peaks: torch.tensor = torch.tensor([]), noise_level=0.1, seed: int = 42):
     """
     Create a test image with known Gaussian peaks.
-    
+
     Args:
         size: Size of the square image
         peaks: (n,5) tensor of peak parameters (amplitude, y, x, sigma_y, sigma_x)
         noise_level: Level of noise to add
-        
+        seed: Seed for the noise generator, applied at generation time so the
+            result doesn't depend on RNG draws from other tests
+
     Returns:
         - Image tensor with Gaussian peaks
     """
     # Create a blank image
-    image = torch.randn((size, size)) * noise_level
+    generator = torch.Generator().manual_seed(seed)
+    image = torch.randn((size, size), generator=generator) * noise_level
 
     gaussian_model = Gaussian2D(
         amplitude=peaks[:, 0],
@@ -34,20 +37,23 @@ def create_test_image(size:int=100, peaks: torch.tensor = torch.tensor([]), nois
 
     return image
 
-def create_test_volume(size:int=100, peaks: torch.tensor = torch.tensor([]), noise_level=0.1):
+def create_test_volume(size:int=100, peaks: torch.tensor = torch.tensor([]), noise_level=0.1, seed: int = 42):
     """
     Create a test volume with known Gaussian peaks.
-    
+
     Args:
         size: Size of the cube volume
         peaks: (n,7) tensor of peak parameters (amplitude, z, y, x, sigma_z, sigma_y, sigma_x)
         noise_level: Level of noise to add
-        
+        seed: Seed for the noise generator, applied at generation time so the
+            result doesn't depend on RNG draws from other tests
+
     Returns:
         - Volume tensor with Gaussian peaks
     """
     # Create a blank volume
-    image = torch.randn((size, size, size)) * noise_level
+    generator = torch.Generator().manual_seed(seed)
+    image = torch.randn((size, size, size), generator=generator) * noise_level
 
     gaussian_model = Gaussian3D(
         amplitude=peaks[:, 0],

--- a/packages/primitives/torch-find-peaks/tests/test_find_peaks.py
+++ b/packages/primitives/torch-find-peaks/tests/test_find_peaks.py
@@ -3,9 +3,6 @@ from _utils import create_test_image, create_test_volume
 
 from torch_find_peaks.find_peaks import find_peaks_2d, find_peaks_3d
 
-# Set global random seed for reproducibility
-torch.manual_seed(42)
-
 
 def test_peak_picking_2d():
     # Format of peaks: [amplitude, y, x, sigma_y, sigma_x]

--- a/packages/primitives/torch-find-peaks/tests/test_refine_peaks.py
+++ b/packages/primitives/torch-find-peaks/tests/test_refine_peaks.py
@@ -3,9 +3,6 @@ from _utils import create_test_image, create_test_volume
 
 from torch_find_peaks.refine_peaks import refine_peaks_2d, refine_peaks_3d
 
-# Set global random seed for reproducibility
-torch.manual_seed(42)
-
 
 def test_refine_peaks_2d_basic():
     """Test basic functionality of 2D Gaussian fitting."""


### PR DESCRIPTION
## Summary

Fixes #123.

`torch.manual_seed(42)` was called once at **module import time** in
`test_refine_peaks.py` and `test_find_peaks.py`, not immediately before
`create_test_image`/`create_test_volume` draw their noise. When run as part
of the full workspace suite, other test modules collected/imported first
consume RNG draws ahead of it, so the noise realization — and thus
`test_refine_peaks_2d_basic`'s Gaussian fit — differs from an isolated run
and can miss tolerance. That's why the test passed reliably in isolation but
failed intermittently as part of the full suite.

## Fix

- `create_test_image`/`create_test_volume` now take a `seed: int = 42`
  parameter and build a local `torch.Generator` right at the point of noise
  generation, instead of relying on global RNG state.
- Dropped the now-redundant module-level `torch.manual_seed(42)` calls in
  both test files (both had the identical pattern, so both were exposed to
  the same bug — `test_find_peaks.py` just has looser tolerances that
  happened to mask it).

## Testing

- `uv run pytest packages/primitives/torch-find-peaks/tests/ -q` — 12 passed
- `uv run pytest -q` (full workspace suite) — `test_refine_peaks_2d_basic`
  passes consistently as part of the full run, which is the exact condition
  the issue reported failing under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtMJR8oiH2mNjTJCEuNctg