### PR TITLE
fix(torch-fourier-filter): make phase-permutation multiset check robust to the wrap boundary

### DIFF
--- a/packages/primitives/torch-fourier-filter/tests/test_phase_randomize.py
+++ b/packages/primitives/torch-fourier-filter/tests/test_phase_randomize.py
@@ -109,6 +109,19 @@ def test_phase_permutation():
     )
 
 
+def _max_circular_nn_distance(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Check `a` and `b` hold the same multiset of angles, up to per-element noise.
+
+    Avoids sort-and-compare: DC/Nyquist bins sit at angle exactly 0 or pi, so
+    a CPU/CUDA rounding difference there can flip one across the 0/2pi wrap
+    and cyclically shift every other bin's sorted rank, producing a large
+    spurious diff. Nearest-neighbor circular distance sidesteps that.
+    """
+    circular_diff = torch.remainder(a.unsqueeze(1) - b.unsqueeze(0) + math.pi, 2 * math.pi) - math.pi
+    dist = circular_diff.abs()
+    return max(dist.min(dim=1).values.max().item(), dist.min(dim=0).values.max().item())
+
+
 def test_phase_permutation_cuton_zero():
     """Full-spectrum permutation uses _permute_all_phases (no freq grid)."""
     image_shape = (24, 24)
@@ -116,19 +129,16 @@ def test_phase_permutation_cuton_zero():
     dft = torch.fft.fft2(torch.rand(image_shape, device=device))
     out = phase_permutation(dft, image_shape, cuton=0, device=device)
     assert torch.allclose(torch.abs(dft), torch.abs(out))
-    # Phase angle is ill-defined where |dft|≈0; cos/sin rebuild also shifts atan2
-    # slightly vs sorted-angle comparison on Windows vs Linux. Compare multiset only
-    # on bins with meaningful magnitude, in float64 with loose tol.
+    # Phase angle is ill-defined where |dft|≈0. Compare multiset only on bins
+    # with meaningful magnitude, in float64.
     mag = torch.abs(dft).flatten()
     mask = mag > 1e-5
     assert mask.any()
-    wo = torch.remainder(
-        torch.angle(dft.flatten()[mask]).double() + math.pi, 2 * math.pi
-    )
-    wp = torch.remainder(
-        torch.angle(out.flatten()[mask]).double() + math.pi, 2 * math.pi
-    )
-    assert torch.allclose(torch.sort(wo)[0], torch.sort(wp)[0], atol=0.02, rtol=0.02)
+    wo = torch.angle(dft.flatten()[mask]).double()
+    wp = torch.angle(out.flatten()[mask]).double()
+    # 1e-4 clears the ~1e-7 float32 noise floor (CPU and CUDA) but is still
+    # far tighter than the ~0.01 rad angle spacing, so real bugs get caught.
+    assert _max_circular_nn_distance(wo, wp) < 1e-4
 
 
 def test_phase_randomize_fftshift():


### PR DESCRIPTION
## Summary

Fixes #124.

`test_phase_permutation_cuton_zero` was flaky specifically on CUDA (this
environment has an NVIDIA GPU, so I could reproduce and verify directly —
it failed ~70% of the time across hundreds of runs before this fix).

## Root cause

The test compared the phases of the original and phase-permuted DFT by
mapping each angle to `[0, 2π)` via `torch.remainder(angle + π, 2π)`,
sorting both arrays, and comparing element-wise with `torch.allclose`.

A real-signal DFT's DC/Nyquist bins have an angle of exactly `0` or `π` —
i.e. exactly on that `remainder`'s wrap boundary. `phase_permutation`
reconstructs the permuted DFT via a `cos`/`sin`/`atan2` round-trip, and a
sub-ULP difference between CPU and CUDA in that round trip can flip such a
bin to the other side of the boundary. That doesn't change the angle in any
meaningful sense, but it does move that one bin from one end of the sorted
array to the other — which cyclically shifts every other bin's rank by one
and makes the element-wise sorted comparison diverge by roughly one
bin-spacing across most of the array, occasionally exceeding the test's
`atol=0.02`.

## Fix

Compare via max nearest-neighbor circular distance (checked in both
directions) instead of a sorted linear-cut comparison, at a tolerance
(`1e-4`) tuned to comfortably clear the observed float32 round-trip noise
floor (~`1e-7` on both CPU and CUDA) while staying well below any genuine
phase difference.

Two weaker approaches I tried and rejected along the way, in case useful
context for review:
- **Just loosening the tolerance** doesn't work — the wrap-boundary cascade
  produces diffs up to ~0.16 rad, an order of magnitude past any tolerance
  that would still catch real corruption.
- **A "sorted circular-gap multiset" comparison** (invariant to the cut,
  like the final fix) turned out to have ~zero discriminating power — it
  also matched two completely *unrelated* random DFTs, since dense
  near-uniform angle samples of the same size have similar gap statistics
  regardless of content.

I verified the final nearest-neighbor approach doesn't share that flaw by
injecting deliberate corruption (single-bin shifts down to 0.01 rad,
10%-of-bins corruption, and comparing against a wholly unrelated DFT) and
confirming it's reliably caught — see Testing below.

## Testing

- 500+ repeated runs of `test_phase_permutation_cuton_zero` on the CUDA box
  used to develop this — 0 false-positive failures (previously ~70% failure
  rate); worst observed nearest-neighbor distance `2.4e-7`.
- 200+ repeated runs forced onto CPU (`CUDA_VISIBLE_DEVICES=`) — 0 false
  positives; worst observed distance `1.2e-7`.
- Bug-injection sanity checks (not part of the committed test, done to make
  sure this fix isn't just a looser check that would let real corruption
  slide through): single-bin phase corruption (0.01–0.5 rad) detected
  200/200 trials; 10%-of-bins corruption and an unrelated-DFT comparison
  both detected reliably.
- Full workspace suite (`uv run pytest -q`) on the CUDA box — 896/896
  passed (previously 895 passed, 1 failed on this exact test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtMJR8oiH2mNjTJCEuNctg