### PR TITLE
chore: sync uv.lock and make CI fail on future lockfile drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             uv.lock
 
       - name: Install all workspace dependencies
-        run: uv sync --all-packages --group test
+        run: uv sync --all-packages --group test --locked
 
       - name: Print environment info
         run: |

--- a/uv.lock
+++ b/uv.lock
@@ -4963,12 +4963,7 @@ test = [
 name = "torch-refine-tilt-axis-angle"
 source = { editable = "packages/algorithms/torch-refine-tilt-axis-angle" }
 dependencies = [
-    { name = "einops" },
     { name = "torch" },
-    { name = "torch-affine-utils" },
-    { name = "torch-cubic-spline-grids" },
-    { name = "torch-fourier-slice" },
-    { name = "torch-grid-utils" },
 ]
 
 [package.dev-dependencies]
@@ -4988,14 +4983,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "einops" },
-    { name = "torch" },
-    { name = "torch-affine-utils", editable = "packages/primitives/torch-affine-utils" },
-    { name = "torch-cubic-spline-grids", editable = "packages/primitives/torch-cubic-spline-grids" },
-    { name = "torch-fourier-slice", editable = "packages/primitives/torch-fourier-slice" },
-    { name = "torch-grid-utils", editable = "packages/primitives/torch-grid-utils" },
-]
+requires-dist = [{ name = "torch" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

`uv.lock` was out of sync with `pyproject.toml`: #105 (the common-line grid
search rewrite) trimmed `torch-refine-tilt-axis-angle`'s dependencies down
to just `torch`, but the lockfile was never regenerated to match. Since
then, every plain `uv run` silently re-resolved and rewrote `uv.lock`
locally, showing up as an unrelated diff on every invocation
(`uv lock --check` failed even on a clean checkout of `main`).

## Changes

- **`uv.lock`**: regenerated via `uv lock`. `uv lock --check` now passes;
  the only diff is dropping `torch-refine-tilt-axis-angle`'s now-unused
  `einops`/`torch-affine-utils`/`torch-cubic-spline-grids`/
  `torch-fourier-slice`/`torch-grid-utils` entries, matching what
  `pyproject.toml` has declared since #105.
- **CI**: added `--locked` to the `uv sync` step in `ci.yml`, so a future
  PR that changes a dependency without re-running `uv lock` fails CI
  immediately with a clear message, instead of drifting silently the way
  this one did.