### PR TITLE
fix(torch-fit-in-map): only pass config to the default simulator

### DIFF
--- a/packages/algorithms/torch-fit-in-map/src/torch_fit_in_map/__init__.py
+++ b/packages/algorithms/torch-fit-in-map/src/torch_fit_in_map/__init__.py
@@ -230,6 +230,38 @@ def apply_alignment(
     )
 
 
+def _simulate_structure(
+    atoms: pd.DataFrame,
+    simulator: PotentialSimulator | None,
+    simulator_config: PotentialSimulatorConfig | None,
+    pixel_size: float,
+    box_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Simulate *atoms* with a custom simulator or the configured default one.
+
+    ``config`` is only passed to the default simulator, so custom simulators
+    implementing ``simulate(atoms, pixel_size, box_size, device)`` without a
+    ``config`` parameter keep working.
+    """
+    if simulator is not None and simulator_config is not None:
+        raise ValueError(
+            "simulator and simulator_config are mutually exclusive; "
+            "simulator_config only configures the default simulator."
+        )
+    if simulator is None:
+        return DEFAULT_POTENTIAL_SIMULATOR.simulate(
+            atoms=atoms,
+            pixel_size=pixel_size,
+            box_size=box_size,
+            device=device,
+            config=simulator_config,
+        )
+    return simulator.simulate(
+        atoms=atoms, pixel_size=pixel_size, box_size=box_size, device=device
+    )
+
+
 def fit_map_in_structure(
     mobile_map: torch.Tensor,
     reference_atoms: pd.DataFrame,
@@ -288,21 +320,13 @@ def fit_map_in_structure(
     ValueError
         If both ``simulator`` and ``simulator_config`` are supplied.
     """
-    if simulator is not None and simulator_config is not None:
-        raise ValueError(
-            "simulator and simulator_config are mutually exclusive; "
-            "simulator_config only configures the default simulator."
-        )
-    if simulator is None:
-        simulator = DEFAULT_POTENTIAL_SIMULATOR
-
-    device = mobile_map.device
-    simulated = simulator.simulate(
-        atoms=reference_atoms,
+    simulated = _simulate_structure(
+        reference_atoms,
+        simulator,
+        simulator_config,
         pixel_size=pixel_size_angstroms,
         box_size=box_size,
-        device=device,
-        config=simulator_config,
+        device=mobile_map.device,
     )
 
     mobile_map, simulated, common_px = normalise_voxel_sizes(
@@ -380,21 +404,13 @@ def fit_structure_in_map(
     ValueError
         If both ``simulator`` and ``simulator_config`` are supplied.
     """
-    if simulator is not None and simulator_config is not None:
-        raise ValueError(
-            "simulator and simulator_config are mutually exclusive; "
-            "simulator_config only configures the default simulator."
-        )
-    if simulator is None:
-        simulator = DEFAULT_POTENTIAL_SIMULATOR
-
-    device = reference_map.device
-    simulated = simulator.simulate(
-        atoms=mobile_atoms,
+    simulated = _simulate_structure(
+        mobile_atoms,
+        simulator,
+        simulator_config,
         pixel_size=pixel_size_angstroms,
         box_size=box_size,
-        device=device,
-        config=simulator_config,
+        device=reference_map.device,
     )
 
     reference_map, simulated, common_px = normalise_voxel_sizes(

--- a/packages/algorithms/torch-fit-in-map/src/torch_fit_in_map/_simulate.py
+++ b/packages/algorithms/torch-fit-in-map/src/torch_fit_in_map/_simulate.py
@@ -77,6 +77,9 @@ class PotentialSimulator(Protocol):
             Target device for the output tensor.
         config : PotentialSimulatorConfig or None
             Simulator options. ``None`` uses the default configuration.
+            :func:`fit_map_in_structure` and :func:`fit_structure_in_map` only
+            pass this to the default simulator, so custom simulators may omit
+            this parameter.
 
         Returns
         -------

--- a/packages/algorithms/torch-fit-in-map/tests/test_dataframe_api.py
+++ b/packages/algorithms/torch-fit-in-map/tests/test_dataframe_api.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 import torch
 from torch_calculate_electrostatic_potential import (
     GridConfig,
@@ -216,3 +217,63 @@ def test_default_simulator_supports_bonded_scattering_factors():
     assert volume.shape == (12, 12, 12)
     assert torch.isfinite(volume).all()
     assert volume.abs().sum() > 0
+
+
+class _SimulatorWithoutConfig(_GaussianSimulator):
+    """Custom simulator whose ``simulate`` does not accept ``config``."""
+
+    def simulate(self, atoms, pixel_size, box_size, device=None):
+        return super().simulate(atoms, pixel_size, box_size, device)
+
+
+def test_custom_simulator_without_config_parameter():
+    """Custom simulators need not accept ``config``."""
+    atoms = _make_atoms()
+    sim = _SimulatorWithoutConfig()
+    box = 24
+    px = 2.0
+    volume = sim.simulate(atoms, px, box)
+    exhaustive_config = ExhaustiveSearchConfig(
+        angular_step_degrees=90.0, pixel_size_angstroms=px
+    )
+
+    structure_in_map = fit_structure_in_map(
+        atoms,
+        volume,
+        px,
+        box,
+        simulator=sim,
+        exhaustive_config=exhaustive_config,
+        gradient_config=None,
+        verbose=False,
+    )
+    map_in_structure = fit_map_in_structure(
+        volume,
+        atoms,
+        px,
+        box,
+        simulator=sim,
+        exhaustive_config=exhaustive_config,
+        gradient_config=None,
+        verbose=False,
+    )
+    assert np.isfinite(structure_in_map.score)
+    assert np.isfinite(map_in_structure.score)
+
+
+@pytest.mark.parametrize("fit", [fit_structure_in_map, fit_map_in_structure])
+def test_simulator_and_simulator_config_are_mutually_exclusive(fit):
+    """A custom simulator cannot be combined with a default-simulator config."""
+    atoms = _make_atoms()
+    volume = torch.zeros(8, 8, 8)
+    args = (atoms, volume) if fit is fit_structure_in_map else (volume, atoms)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        fit(
+            *args,
+            2.0,
+            8,
+            simulator=_GaussianSimulator(),
+            simulator_config=PotentialSimulatorConfig(),
+            verbose=False,
+        )


### PR DESCRIPTION
Follow-up to #121.

## Problem
`fit_map_in_structure` and `fit_structure_in_map` always call `simulator.simulate(..., config=simulator_config)`, even when `simulator_config` is `None`. A custom simulator without a `config` parameter therefore fails with `TypeError: ... got an unexpected keyword argument 'config'`. That happens even though `simulator` and `simulator_config` are already mutually exclusive, so a custom simulator never needs `config`.

This breaks the slow test `test_structure_in_map_recovery`. CI doesn't run slow tests, which is why the failure went unnoticed.

## Changes
- **New helper:** `_simulate_structure`, a private function in `torch_fit_in_map/__init__.py`, used by both fit functions. It keeps the existing mutual-exclusion `ValueError` and passes `config` only to the default simulator.
- **Docstring:** the `PotentialSimulator` docstring now says custom simulators may omit `config`.
- **New fast tests in `tests/test_dataframe_api.py`:**
  - a custom simulator without `config` works with both fit functions
  - passing both `simulator` and `simulator_config` raises `ValueError`

## Testing
- **New test:** it fails on current `main` with the `TypeError` above and passes with this change.
- **Test suite:** `uv run pytest packages/algorithms/torch-fit-in-map` gives 35 passed.
- **mypy:** strict mypy is clean.
- **ruff:** `ruff check` and `ruff format --check` are clean on the changed files.
- **Slow test:** `test_structure_in_map_recovery` is re-running; I'll comment with the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8BYa1SnVKWtM4UqGSxns1
