### PR TITLE
style(torch-ctf-estimation): fix ruff and mypy failures from #115

### DIFF
--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/equiphase_ctf_1d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/equiphase_ctf_1d.py
@@ -188,7 +188,7 @@ def _equiphase_s_scale_window(
     defocus_um: float | torch.Tensor,
     astigmatism_um: float | torch.Tensor,
 ) -> tuple[float, float]:
-    """Scale window around shell |q| for the local χ root (not the Cs-turnover alias)."""
+    """Scale window around shell |q| for the local chi root (not Cs-turnover alias)."""
     if isinstance(defocus_um, torch.Tensor):
         df = abs(float(defocus_um.detach().cpu().reshape(-1)[0].item()))
     else:

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_ctf_1d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_ctf_1d.py
@@ -1,7 +1,6 @@
 """Estimate CTF in 1D from a power spectrum."""
 
 from collections.abc import Callable
-from typing import Optional
 
 import torch
 from torch_grid_utils.fftfreq_grid import fftfreq_to_spatial_frequency
@@ -35,7 +34,7 @@ def estimate_ctf_1d(
     refine_steps: int = 40,
     refine_defocus_lr: float = 0.01,
     refine_b_factor_lr: float = 1.0,
-    initial_defocus: Optional[float] = None,
+    initial_defocus: float | None = None,
     background_result: _Background1DResult | None = None,
     optimize_phase_shift: bool = False,
     initial_phase_shift: float = 0.0,
@@ -105,7 +104,7 @@ def estimate_ctf_1d(
         Initial phase shift in degrees when optimize_phase_shift is True. Default 0.0.
     phase_shift_range : tuple[float, float] or None
         (low, high) phase shift bounds in degrees. If None, phase is unbounded
-        during refinement (grid search uses 0–180° internally).
+        during refinement (grid search uses 0-180 degrees internally).
     phase_shift_step : float
         Phase shift grid step in degrees for grid search. Default 5.0.
     phase_shift_lr : float
@@ -262,10 +261,10 @@ def estimate_ctf_1d(
     # Step 3: Refinement — gradient descent from grid (unless refine_steps<=0)
     # -------------------------------------------------------------------------
     if refine_steps > 0:
-        initial_B_float: Optional[float] = None
+        initial_B_float: float | None = None
         if grid_result.best_B is not None:
             initial_B_float = float(grid_result.best_B.detach().cpu().item())
-        initial_phase_float: Optional[float] = None
+        initial_phase_float: float | None = None
         if grid_result.best_phase_shift is not None:
             initial_phase_float = float(
                 grid_result.best_phase_shift.detach().cpu().item()

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_ctf_1d_utils.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_ctf_1d_utils.py
@@ -523,7 +523,9 @@ def grid_search_defocus_and_envelope_1d(
         Phase shift grid step in degrees when optimize_phase_shift is True. Default 5.0.
     phase_shift_range : tuple[float, float] or None
         (low, high) phase shift bounds in degrees for the grid search. If None,
-        a wide internal range (0–180°) is used for search only.
+        a wide internal range (0-180 degrees) is used for search only.
+    fixed_phase_shift_deg : float
+        Phase shift in degrees used when optimize_phase_shift is False.
 
     Returns
     -------
@@ -686,7 +688,7 @@ def grid_search_defocus_and_envelope_1d(
 
 def refine_defocus_and_b_factor_1d(
     initial_defocus: float,
-    initial_B: Optional[float],
+    initial_B: float | None,
     raps_in_fit_range: torch.Tensor,
     spatial_freqs: torch.Tensor,
     fit_mask: torch.Tensor,
@@ -700,12 +702,12 @@ def refine_defocus_and_b_factor_1d(
     n_iterations: int = 100,
     defocus_lr: float = 0.01,
     b_factor_lr: float = 1.0,
-    initial_phase_shift: Optional[float] = None,
+    initial_phase_shift: float | None = None,
     optimize_phase_shift: bool = False,
     phase_shift_lr: float = 5.0,
     phase_shift_range: tuple[float, float] | None = None,
     early_stopper: Callable[[float], bool] | None = None,
-) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     """
     Refine defocus (and optionally B factor) by gradient descent to maximise ZNCC.
 

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_gof_resolution_1d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_gof_resolution_1d.py
@@ -11,7 +11,7 @@ This module is a diagnostic. It does not replace the 1D thickness grid.
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import torch
 from torch_ctf import calculate_ctf_1d
@@ -22,7 +22,9 @@ from torch_ctf_estimation.metrics.fit_metrics import (
     l2_normalized_cross_correlation,
     pearson_r_flat,
 )
-from torch_ctf_estimation.models.results_models import Thickness1DResults
+
+if TYPE_CHECKING:
+    from torch_ctf_estimation.models.results_models import Thickness1DResults
 
 
 class GofResolution1DResult(NamedTuple):
@@ -40,8 +42,10 @@ def electron_wavelength_angstrom(voltage_kev: float) -> float:
     return float(lam_m.detach().cpu().item()) * 1.0e10
 
 
-def thickness_from_first_node_angstroms(d_angstroms: float, voltage_kev: float) -> float:
-    """t = 1 / (lambda * g^2) = d^2 / lambda (first CTF_t node)."""
+def thickness_from_first_node_angstroms(
+    d_angstroms: float, voltage_kev: float
+) -> float:
+    """T = 1 / (lambda * g^2) = d^2 / lambda (first CTF_t node)."""
     if d_angstroms <= 0.0 or not torch.isfinite(torch.tensor(d_angstroms)):
         return float("nan")
     return (d_angstroms**2) / electron_wavelength_angstrom(voltage_kev)
@@ -144,9 +148,7 @@ def estimate_gof_resolution_1d(
     fit_res = interpolate_cc_drop_angstroms(spacing[valid], r[valid], cc_threshold)
     return GofResolution1DResult(
         fit_res_A=fit_res,
-        thickness_from_node_A=thickness_from_first_node_angstroms(
-            fit_res, voltage_kev
-        ),
+        thickness_from_node_A=thickness_from_first_node_angstroms(fit_res, voltage_kev),
         spacing_A=spacing[valid],
         window_pearson_r=r[valid],
     )
@@ -234,7 +236,7 @@ def simulate_thickness_abs_ctf_1d(
     pixel_spacing_angstroms: float,
     phase_shift_deg: float = 0.0,
 ) -> torch.Tensor:
-    """|CTF_t| amplitude transfer (sinc × sin χ)."""
+    """|CTF_t| amplitude transfer (sinc * sin chi)."""
     ctf = calculate_ctf_thickness_1d(
         return_power_spectrum=False,
         sample_thickness_angstrom=thickness_angstroms,
@@ -297,7 +299,7 @@ def estimate_gof_by_cycles(
         if cycles_per_window <= 1.0 + 1e-6:
             i1 = peaks[i + 1]
         else:
-            i1 = int(round(i0 + cycles_per_window * span))
+            i1 = round(i0 + cycles_per_window * span)
             i1 = min(max(i1, i0 + min_bins), n - 1)
         if i1 - i0 < min_bins:
             continue
@@ -327,9 +329,7 @@ def estimate_gof_by_cycles(
     fit_res = interpolate_cc_drop_angstroms(spacing, cc, cc_threshold)
     return GofResolution1DResult(
         fit_res_A=fit_res,
-        thickness_from_node_A=thickness_from_first_node_angstroms(
-            fit_res, voltage_kev
-        ),
+        thickness_from_node_A=thickness_from_first_node_angstroms(fit_res, voltage_kev),
         spacing_A=spacing,
         window_pearson_r=cc,
     )

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_thickness_1d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/estimate_thickness_1d.py
@@ -1,7 +1,5 @@
 """Estimate sample thickness in 1D from a power spectrum."""
 
-from typing import Optional
-
 import einops
 import torch
 from torch_ctf.ctf_thickness import calculate_ctf_thickness_1d
@@ -29,13 +27,13 @@ def estimate_thickness_1d(
     phase_shift_deg: float = 0.0,
     thickness_range_angstroms: tuple[float, float] = (300.0, 4000.0),
     thickness_step_angstroms: float = 100.0,
-    background_result: Optional[_Background1DResult] = None,
+    background_result: _Background1DResult | None = None,
     use_equiphase: bool = False,
-    equiphase_defocus_um: Optional[float] = None,
-    equiphase_astigmatism_um: Optional[float] = None,
-    equiphase_astigmatism_angle_deg: Optional[float] = None,
-    equiphase_phase_shift_deg: Optional[float] = None,
-    laser_params: Optional[LaserParams] = None,
+    equiphase_defocus_um: float | None = None,
+    equiphase_astigmatism_um: float | None = None,
+    equiphase_astigmatism_angle_deg: float | None = None,
+    equiphase_phase_shift_deg: float | None = None,
+    laser_params: LaserParams | None = None,
     equiphase_n_theta: int = 64,
 ) -> Thickness1DResults:
     """

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/refine_defocus_and_thickness_1d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_1d/refine_defocus_and_thickness_1d.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,8 +39,8 @@ def refine_defocus_and_thickness_1d(
     thickness_lr: float = 50.0,
     defocus_range_microns: tuple[float, float] | None = None,
     thickness_range_angstroms: tuple[float, float] = (300.0, 4000.0),
-    background_result: Optional[_Background1DResult] = None,
-    laser_params: Optional[LaserParams] = None,
+    background_result: _Background1DResult | None = None,
+    laser_params: LaserParams | None = None,
     early_stopper: Callable[[float], bool] | None = None,
     use_equiphase: bool = False,
     equiphase_defocus_um: float | None = None,
@@ -89,6 +89,19 @@ def refine_defocus_and_thickness_1d(
     early_stopper : callable or None, optional
         Stateful ``(loss) -> should_stop`` callback. Default None (run all
         ``n_iterations``).
+    use_equiphase : bool, optional
+        If True, compute the background/1D profile with equiphase averaging
+        instead of a plain rotational average. Default False.
+    equiphase_defocus_um : float or None, optional
+        Defocus in micrometers used for equiphase averaging. Default None.
+    equiphase_astigmatism_um : float or None, optional
+        Astigmatism in micrometers used for equiphase averaging. Default None.
+    equiphase_astigmatism_angle_deg : float or None, optional
+        Astigmatism angle in degrees used for equiphase averaging. Default None.
+    equiphase_phase_shift_deg : float or None, optional
+        Phase shift in degrees used for equiphase averaging. Default None.
+    equiphase_n_theta : int, optional
+        Number of azimuthal samples for equiphase averaging. Default 64.
     optimize_defocus : bool, optional
         If False, keep defocus at ``initial_defocus_um`` and refine thickness
         only. Default True.
@@ -140,9 +153,7 @@ def refine_defocus_and_thickness_1d(
             ]
         )
     else:
-        defocus_param = torch.tensor(
-            initial_defocus_um, device=device, dtype=dtype
-        )
+        defocus_param = torch.tensor(initial_defocus_um, device=device, dtype=dtype)
         optimiser = torch.optim.Adam(
             [{"params": [thickness_param], "lr": thickness_lr}]
         )

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_ctf_2d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_ctf_2d.py
@@ -1,7 +1,7 @@
 """Estimate CTF in 2D from a power spectrum."""
 
 from collections.abc import Callable
-from typing import Literal, Optional
+from typing import Literal
 
 import torch
 
@@ -34,7 +34,7 @@ def estimate_ctf_2d(
     initial_defocus_gradient_angle: float = 0.0,
     defocus_gradient_magnitude_lr: float = 0.05,
     defocus_gradient_angle_lr: float = 50.0,
-    fix_defocus_0: Optional[float] = None,
+    fix_defocus_0: float | None = None,
     debug: bool = False,
     optimize_phase_shift: bool = False,
     phase_shift_model: Literal["grid", "quadratic"] = "grid",
@@ -44,8 +44,8 @@ def estimate_ctf_2d(
     voltage_kev: float = 300.0,
     spherical_aberration_mm: float = 2.7,
     amplitude_contrast_fraction: float = 0.07,
-    laser_params: Optional[LaserParams] = None,
-    axis_mask: Optional[torch.Tensor] = None,
+    laser_params: LaserParams | None = None,
+    axis_mask: torch.Tensor | None = None,
     defocus_bounds_microns: tuple[float, float] | None = None,
     phase_shift_bounds_degrees: tuple[float, float] | None = None,
     fixed_phase_shift_deg: float | None = None,
@@ -146,6 +146,9 @@ def estimate_ctf_2d(
     early_stopper : callable or None, optional
         Stateful ``(loss) -> should_stop`` callback. Default None (run all
         ``n_iterations``).
+    use_amplitude : bool, optional
+        If True, fit against the CTF amplitude rather than CTF squared.
+        Default False.
 
     Returns
     -------

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_ctf_2d_utils.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_ctf_2d_utils.py
@@ -2,7 +2,7 @@
 
 import math
 from collections.abc import Callable
-from typing import Literal, Optional
+from typing import Literal
 
 import torch
 from torch_fourier_filter.bandpass import bandpass_filter
@@ -51,7 +51,7 @@ def _shared_astigmatism_and_env(
     initial_astigmatism_angle: float,
     optimize_astigmatism: bool,
     initial_envelope_B: float,
-    axis_mask: Optional[torch.Tensor] = None,
+    axis_mask: torch.Tensor | None = None,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -210,8 +210,8 @@ def estimate_defocus_2d_at_1x1(
     voltage_kev: float = 300.0,
     spherical_aberration_mm: float = 2.7,
     amplitude_contrast_fraction: float = 0.07,
-    laser_params: Optional[LaserParams] = None,
-    axis_mask: Optional[torch.Tensor] = None,
+    laser_params: LaserParams | None = None,
+    axis_mask: torch.Tensor | None = None,
     defocus_bounds_microns: tuple[float, float] | None = None,
     phase_shift_bounds_degrees: tuple[float, float] | None = None,
     fixed_phase_shift_deg: float | None = None,
@@ -258,9 +258,20 @@ def estimate_defocus_2d_at_1x1(
     laser_params : Optional[LaserParams], optional
         If set and ``model_laser`` is True, use LPP CTF model for 2D fit; if None
         or ``model_laser`` is False, use standard CTF. Default None.
+    axis_mask : torch.Tensor or None, optional
+        Optional laser-axis mask applied during the 2D fit. Default None.
+    defocus_bounds_microns : tuple[float, float] or None, optional
+        Defocus clamp bounds in micrometers. Default None (unbounded).
+    phase_shift_bounds_degrees : tuple[float, float] or None, optional
+        Phase shift bounds in degrees. Default None (0-180 degrees).
+    fixed_phase_shift_deg : float or None, optional
+        Phase shift in degrees held fixed when not optimizing. Default None.
     early_stopper : callable or None, optional
         Stateful ``(loss) -> should_stop`` callback passed through to the 1x1
         grid fit. Default None (run all ``n_iterations``).
+    use_amplitude : bool, optional
+        If True, fit against the CTF amplitude rather than CTF squared.
+        Default False.
 
     Returns
     -------

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_defocus_2d_grid.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_defocus_2d_grid.py
@@ -7,7 +7,7 @@ Optimisation fits the grid control points plus optional astigmatism and phase sh
 
 import math
 from collections.abc import Callable
-from typing import Literal, Optional
+from typing import Literal
 
 import einops
 import torch
@@ -72,7 +72,7 @@ def _setup_grid_defocus_and_phase(
     phase_shift_model: Literal["grid", "quadratic"],
     initial_phase_shift: float,
     phase_shift_quadratic_perpendicular_axis: bool = False,
-) -> tuple[CubicCatmullRomGrid3d, Optional[PhaseShiftModels]]:
+) -> tuple[CubicCatmullRomGrid3d, PhaseShiftModels | None]:
     """
     Create the 3D defocus spline grid and optional phase shift models.
 
@@ -104,7 +104,7 @@ def _build_grid_param_groups(
     angle_v: torch.Tensor,
     astigmatism_lr: float,
     astigmatism_angle_lr: float,
-    phase_models: Optional[PhaseShiftModels],
+    phase_models: PhaseShiftModels | None,
     phase_shift_lr: float,
 ) -> list[dict]:
     """Build Adam param groups: defocus grid, then astigmatism, then phase."""
@@ -176,8 +176,8 @@ def estimate_defocus_2d_grid(
     voltage_kev: float = 300.0,
     spherical_aberration_mm: float = 2.7,
     amplitude_contrast_fraction: float = 0.10,
-    laser_params: Optional[LaserParams] = None,
-    axis_mask: Optional[torch.Tensor] = None,
+    laser_params: LaserParams | None = None,
+    axis_mask: torch.Tensor | None = None,
     defocus_bounds_microns: tuple[float, float] | None = None,
     phase_shift_bounds_degrees: tuple[float, float] | None = None,
     fixed_phase_shift_deg: float | None = None,

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_defocus_2d_linear.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_defocus_2d_linear.py
@@ -8,7 +8,7 @@ When nt > 1, defocus_0 / gradient / angle can be 1D splines in t; otherwise scal
 import math
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal, Optional, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import einops
 import torch
@@ -62,15 +62,15 @@ class _LinearDefocusParams:
     Exactly one of (spline branch) or (scalar branch) is set; the other is None.
     """
 
-    defocus_0_fixed: Optional[float]
-    defocus_0_param: Optional[torch.nn.Parameter]
-    grad_mag_param: Optional[torch.nn.Parameter]
-    grad_angle_u: Optional[torch.nn.Parameter]
-    grad_angle_v: Optional[torch.nn.Parameter]
-    defocus_0_spline_1d: Optional[_Spline1D]
-    grad_mag_spline_1d: Optional[_Spline1D]
-    grad_angle_u_spline_1d: Optional[_Spline1D]
-    grad_angle_v_spline_1d: Optional[_Spline1D]
+    defocus_0_fixed: float | None
+    defocus_0_param: torch.nn.Parameter | None
+    grad_mag_param: torch.nn.Parameter | None
+    grad_angle_u: torch.nn.Parameter | None
+    grad_angle_v: torch.nn.Parameter | None
+    defocus_0_spline_1d: _Spline1D | None
+    grad_mag_spline_1d: _Spline1D | None
+    grad_angle_u_spline_1d: _Spline1D | None
+    grad_angle_v_spline_1d: _Spline1D | None
 
 
 def _setup_linear_spectra_and_shape(
@@ -100,7 +100,7 @@ def _setup_linear_defocus_params(
     initial_defocus: float,
     initial_defocus_gradient_angle: float,
     initial_defocus_gradient_magnitude: float,
-    fix_defocus_0: Optional[float],
+    fix_defocus_0: float | None,
 ) -> _LinearDefocusParams:
     """
     Create linear defocus parameters.
@@ -372,7 +372,7 @@ def _build_linear_param_groups(
     angle_v: torch.Tensor,
     astigmatism_lr: float,
     astigmatism_angle_lr: float,
-    phase_models: Optional[PhaseShiftModels],
+    phase_models: PhaseShiftModels | None,
     phase_shift_lr: float,
 ) -> list[dict]:
     """Build Adam param groups for linear defocus, astigmatism, and phase."""
@@ -440,7 +440,7 @@ def _build_linear_param_groups(
     return param_groups
 
 
-def _spline_data_or_none(spline: Optional[_Spline1D]) -> Optional[torch.Tensor]:
+def _spline_data_or_none(spline: _Spline1D | None) -> torch.Tensor | None:
     """Return spline.data.detach().clone() or None; avoids union-attr on optional."""
     if spline is None:
         return None
@@ -485,7 +485,7 @@ def estimate_defocus_2d_linear(
     initial_defocus_gradient_angle: float = 0.0,
     defocus_gradient_magnitude_lr: float = 0.05,
     defocus_gradient_angle_lr: float = 50.0,
-    fix_defocus_0: Optional[float] = None,
+    fix_defocus_0: float | None = None,
     debug: bool = False,
     optimize_phase_shift: bool = False,
     phase_shift_model: Literal["grid", "quadratic"] = "grid",
@@ -495,8 +495,8 @@ def estimate_defocus_2d_linear(
     voltage_kev: float = 300.0,
     spherical_aberration_mm: float = 2.7,
     amplitude_contrast_fraction: float = 0.10,
-    laser_params: Optional[LaserParams] = None,
-    axis_mask: Optional[torch.Tensor] = None,
+    laser_params: LaserParams | None = None,
+    axis_mask: torch.Tensor | None = None,
     defocus_bounds_microns: tuple[float, float] | None = None,
     phase_shift_bounds_degrees: tuple[float, float] | None = None,
     fixed_phase_shift_deg: float | None = None,

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_defocus_2d_linear.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/estimate_defocus_2d_linear.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, TypeAlias
 
 import einops
 import torch
+from torch_cubic_spline_grids import CubicCatmullRomGrid1d
 
 from torch_ctf_estimation.estimate_ctf_2d.ctf_loss_2d import (
     compute_ctf2_t,
@@ -47,11 +48,6 @@ from torch_ctf_estimation.utils.fitting_bounds import (
 
 # Type for 1D spline params; use Any to avoid two TypeAlias assignments
 _Spline1D: TypeAlias = Any
-
-try:
-    from torch_cubic_spline_grids import CubicCatmullRomGrid1d
-except ImportError:
-    CubicCatmullRomGrid1d = None
 
 
 @dataclass
@@ -116,7 +112,7 @@ def _setup_linear_defocus_params(
         if initial_defocus_gradient_magnitude != 0
         else 0.05
     )
-    use_linear_splines = nt > 1 and CubicCatmullRomGrid1d is not None
+    use_linear_splines = nt > 1
 
     if use_linear_splines:
         if fix_defocus_0 is not None:

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/phase_shift_2d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/phase_shift_2d.py
@@ -2,7 +2,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal
 
 import torch
 from torch_cubic_spline_grids import CubicCatmullRomGrid3d
@@ -18,9 +18,9 @@ class PhaseShiftModels:
     When not optimizing phase, u_grid and v_grid are None and quad_params is None.
     """
 
-    u_grid: Optional[CubicCatmullRomGrid3d] = None
-    v_grid: Optional[CubicCatmullRomGrid3d] = None
-    quad_params: Optional[dict[str, torch.nn.Parameter]] = None
+    u_grid: CubicCatmullRomGrid3d | None = None
+    v_grid: CubicCatmullRomGrid3d | None = None
+    quad_params: dict[str, torch.nn.Parameter] | None = None
     quadratic_perpendicular_axis: bool = False
 
 
@@ -31,7 +31,7 @@ def init_phase_shift_models(
     grid_resolution: tuple[int, int, int],
     device: torch.device,
     phase_shift_quadratic_perpendicular_axis: bool = False,
-) -> Optional[PhaseShiftModels]:
+) -> PhaseShiftModels | None:
     """
     Initialise phase shift models (grid u/v or quadratic params).
 
@@ -87,10 +87,10 @@ def init_phase_shift_models(
 
 def phase_shift_at_positions(
     positions_t: torch.Tensor,
-    phase_models: Optional[PhaseShiftModels],
+    phase_models: PhaseShiftModels | None,
     phase_shift_bounds: tuple[float, float] | None = None,
     fixed_phase_shift_deg: float | None = None,
-) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     """
     Evaluate phase shift (and u, v for unit-circle penalty) at normalised positions.
 
@@ -145,7 +145,7 @@ def phase_shift_at_positions(
 
 
 def clamp_phase_shift_after_step(
-    phase_models: Optional[PhaseShiftModels],
+    phase_models: PhaseShiftModels | None,
     phase_shift_bounds: tuple[float, float] | None = None,
 ) -> None:
     """Clamp quadratic C and grid u/v mean phase after optimizer step."""
@@ -167,9 +167,7 @@ def clamp_phase_shift_after_step(
         with torch.no_grad():
             u_mean = phase_models.u_grid.data.mean()
             v_mean = phase_models.v_grid.data.mean()
-            phase_deg = (
-                0.5 * torch.atan2(v_mean, u_mean) * (180.0 / math.pi)
-            ).item()
+            phase_deg = (0.5 * torch.atan2(v_mean, u_mean) * (180.0 / math.pi)).item()
             phase_deg = max(lo, min(hi, phase_deg))
             theta_rad = phase_deg * (math.pi / 180.0)
             u_new = math.cos(2.0 * theta_rad)
@@ -179,9 +177,9 @@ def clamp_phase_shift_after_step(
 
 
 def build_phase_shift_result(
-    phase_models: Optional[PhaseShiftModels],
+    phase_models: PhaseShiftModels | None,
     _phase_shift_model: Literal["grid", "quadratic"],
-) -> tuple[Optional[float], Optional[object]]:
+) -> tuple[float | None, object | None]:
     """
     Build (final_phase_shift_deg, final_phase_shift_model_obj) for Defocus2DResults.
 
@@ -215,7 +213,7 @@ def build_phase_shift_result(
 
 
 def phase_shift_param_groups(
-    phase_models: Optional[PhaseShiftModels],
+    phase_models: PhaseShiftModels | None,
     phase_shift_lr: float,
 ) -> list[dict]:
     """Return param groups for Adam for phase shift models."""
@@ -233,8 +231,8 @@ def phase_shift_param_groups(
 
 
 def phase_shift_trace_value(
-    phase_models: Optional[PhaseShiftModels],
-) -> Optional[float]:
+    phase_models: PhaseShiftModels | None,
+) -> float | None:
     """Single scalar for trace list (mean phase this step)."""
     if phase_models is None:
         return None

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/refine_defocus_and_thickness_2d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/estimate_ctf_2d/refine_defocus_and_thickness_2d.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -50,8 +50,8 @@ def refine_defocus_and_thickness_2d(
     thickness_lr: float = 50.0,
     thickness_grid_resolution: tuple[int, int, int] | None = None,
     defocus_bounds_microns: tuple[float, float] | None = None,
-    laser_params: Optional[LaserParams] = None,
-    axis_mask: Optional[torch.Tensor] = None,
+    laser_params: LaserParams | None = None,
+    axis_mask: torch.Tensor | None = None,
     early_stopper: Callable[[float], bool] | None = None,
 ) -> tuple[Defocus2DResults, Thickness2DResults]:
     """Jointly refine 2D defocus and thickness with the thickness-modulated CTF.
@@ -74,6 +74,12 @@ def refine_defocus_and_thickness_2d(
         Fit band in Angstroms.
     pixel_spacing_angstroms : float
         Pixel size after any rescale.
+    voltage_kev : float, optional
+        Acceleration voltage in keV. Default 300.0.
+    spherical_aberration_mm : float, optional
+        Spherical aberration in mm. Default 2.7.
+    amplitude_contrast_fraction : float, optional
+        Amplitude contrast fraction (0-1). Default 0.07.
     n_iterations, defocus_lr, thickness_lr :
         Optimiser settings.
     thickness_grid_resolution : tuple[int, int, int] | None
@@ -169,7 +175,10 @@ def refine_defocus_and_thickness_2d(
         )
         param_groups = [
             {"params": [defocus_0_param], "lr": defocus_lr},
-            {"params": [grad_mag_param, angle_u_param, angle_v_param], "lr": defocus_lr},
+            {
+                "params": [grad_mag_param, angle_u_param, angle_v_param],
+                "lr": defocus_lr,
+            },
             {"params": list(thickness_model.parameters()), "lr": thickness_lr},
         ]
     else:
@@ -289,10 +298,12 @@ def refine_defocus_and_thickness_2d(
         av = float(angle_v_param.detach().cpu().item())
         angle_deg = (math.atan2(av, au) * 180.0 / math.pi + 180.0) % 180.0
         mean_defocus = float(defocus_0_param.detach().cpu().item())
-        updated_defocus: LinearDefocusModel | CubicCatmullRomGrid3d = LinearDefocusModel(
-            defocus_0=mean_defocus,
-            defocus_gradient_magnitude=float(grad_mag_param.detach().cpu().item()),
-            defocus_gradient_angle=angle_deg,
+        updated_defocus: LinearDefocusModel | CubicCatmullRomGrid3d = (
+            LinearDefocusModel(
+                defocus_0=mean_defocus,
+                defocus_gradient_magnitude=float(grad_mag_param.detach().cpu().item()),
+                defocus_gradient_angle=angle_deg,
+            )
         )
         model_type = "linear"
     else:

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/models/__init__.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/models/__init__.py
@@ -38,12 +38,12 @@ __all__ = [
     "LinearDefocusModel",
     "LinearDefocusOutput",
     "OpticalParams",
-    "ThicknessParams",
     "PhaseShiftGridOutput",
     "PhaseShiftParamsOutput",
     "PhaseShiftQuadraticOutput",
     "QuadraticPhaseShiftModel",
     "Thickness1DResults",
     "Thickness2DResults",
+    "ThicknessParams",
     "linear_tilt_axis_and_magnitude_deg",
 ]

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/models/input_models.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/models/input_models.py
@@ -62,8 +62,9 @@ class CTFFittingParams(_EarlyStoppingMixin):
     phase_shift_range_degrees: tuple[float, float] | None = Field(
         default=None,
         description=(
-            "Phase shift bounds in degrees for 1D/2D fitting. Default (0, 180) when unset. "
-            "Equal values, e.g. (45.0, 45.0), use a known fixed phase (overrides optimize_phase_shift)."
+            "Phase shift bounds in degrees for 1D/2D fitting. Default (0, 180) "
+            "when unset. Equal values, e.g. (45.0, 45.0), use a known fixed phase "
+            "(overrides optimize_phase_shift)."
         ),
     )
     patch_sidelength: int = 256

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/__init__.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for CTF estimation."""

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/defocus_field_from_1d.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/defocus_field_from_1d.py
@@ -2,7 +2,7 @@
 
 import math
 import warnings
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import torch
 from torch_cubic_spline_grids import CubicCatmullRomGrid3d
@@ -32,7 +32,7 @@ def defocus_field_from_1d_fits(
     b_range_1d: tuple[float, float],
     b_step_1d: float,
     refine_steps_1d: int,
-    background_result: Optional[Any],
+    background_result: Any | None,
     device: torch.device,
     optimize_phase_shift: bool = False,
     use_equiphase_for_1d_spatial: bool = False,

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/fitting_bounds.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/fitting_bounds.py
@@ -51,7 +51,7 @@ def resolve_phase_shift_fitting(
     phase_shift_deg : float
         Phase shift used in the CTF (fixed value or initial for optimisation).
     phase_bounds : tuple[float, float]
-        Effective bounds (always set; defaults to 0–180°).
+        Effective bounds (always set; defaults to 0-180 degrees).
     """
     phase_bounds = resolve_phase_shift_bounds(phase_shift_range_degrees)
     if bounds_are_fixed(phase_bounds):

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/plotting.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/plotting.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError as err:
 def _fit_band_background_subtracted_normalized(
     results1d: Defocus1DResults,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fit-band background-subtracted power, min-max normalized (same as plot_1d panel 3)."""
+    """Fit-band background-subtracted power, min-max normalized (plot_1d panel 3)."""
     if (
         results1d.background_model is None
         or results1d.low_frequency_fit is None
@@ -55,7 +55,9 @@ def _simulated_ctf2_fit_band(
 ) -> torch.Tensor:
     """Simulated CTF^2 on the 1D fit band (same method as plot_1d panel 3)."""
     if results1d.ctf_model is None or results1d.low_frequency_fit is None:
-        raise ValueError("Simulated CTF^2 plot requires ctf_model and fit-range limits.")
+        raise ValueError(
+            "Simulated CTF^2 plot requires ctf_model and fit-range limits."
+        )
 
     freqs = results1d.frequencies_1d
     fit_mask = (freqs >= results1d.low_frequency_fit) & (
@@ -97,6 +99,8 @@ def plot_1d_spectrum(results1d: Defocus1DResults) -> None:
 
     # Plot 1: 1D Power Spectrum with background
     ax1 = axes[0, 0]
+    if results1d.powerspectrum_1d is None:
+        raise ValueError("Defocus1DResults.powerspectrum_1d is required")
     freqs = results1d.frequencies_1d.detach().cpu().numpy()
     power_spec = results1d.powerspectrum_1d.detach().cpu().numpy()
 
@@ -173,8 +177,8 @@ def plot_1d_spectrum(results1d: Defocus1DResults) -> None:
         and results1d.low_frequency_fit is not None
     ):
         ax3 = axes[1, 0]
-        fit_freqs, corrected_power_normalized = _fit_band_background_subtracted_normalized(
-            results1d
+        fit_freqs, corrected_power_normalized = (
+            _fit_band_background_subtracted_normalized(results1d)
         )
         fit_freqs_np = fit_freqs.numpy()
 
@@ -342,7 +346,9 @@ def plot_2d_spectrum(
     if results2d.envelope_B is not None:
         ctf_info.append(f"Envelope B: {results2d.envelope_B:.1f}")
     if results2d.cross_correlation_final is not None:
-        ctf_info.append(f"2D cross-correlation: {results2d.cross_correlation_final:.3f}")
+        ctf_info.append(
+            f"2D cross-correlation: {results2d.cross_correlation_final:.3f}"
+        )
     ctf_info.extend(
         [
             "",
@@ -470,7 +476,9 @@ def plot_2d_spectrum_images(
     axes[0].set_title("Measured power spectrum (2D)")
     axes[0].axis("off")
 
-    axes[1].imshow(simulated_img, cmap="gray", vmin=0, vmax=255, interpolation="nearest")
+    axes[1].imshow(
+        simulated_img, cmap="gray", vmin=0, vmax=255, interpolation="nearest"
+    )
     axes[1].set_title("Simulated CTF^2 (2D fit)")
     axes[1].axis("off")
 

--- a/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/prepare_image.py
+++ b/packages/algorithms/torch-ctf-estimation/src/torch_ctf_estimation/utils/prepare_image.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import einops
-import torch
 from torch_fourier_rescale import fourier_rescale_2d
 
 from torch_ctf_estimation.utils.normalize import normalize_image
+
+if TYPE_CHECKING:
+    import torch
 
 
 def prepare_image_for_ctf(

--- a/packages/algorithms/torch-ctf-estimation/tests/test_joint_refine.py
+++ b/packages/algorithms/torch-ctf-estimation/tests/test_joint_refine.py
@@ -145,9 +145,7 @@ def test_refine_defocus_and_thickness_2d_early_stops_before_n_iterations():
         pixel_spacing_angstroms=1.5,
         n_iterations=n_iterations,
         thickness_grid_resolution=(1, 1, 1),
-        early_stopper=make_early_stopper(
-            patience=1, window_size=2, tolerance=1e6
-        ),
+        early_stopper=make_early_stopper(patience=1, window_size=2, tolerance=1e6),
     )
     assert out2d.defocus_model_type == "grid"
     assert thick2d.loss_trace is not None


### PR DESCRIPTION
The merge of #115 landed with pre-commit failing. Apply ruff autofixes and formatting, then resolve the remaining manual lint errors: rewrap long lines, replace ambiguous Unicode in docstrings, document missing parameters, add the utils package docstring, move annotation-only imports into TYPE_CHECKING blocks, and drop a redundant int(round(...)).

Also guard the optional powerspectrum_1d before dereferencing it in plot_1d_spectrum, matching the existing pattern in estimate_gof_resolution_1d.